### PR TITLE
feat: add CI workflow and scroll-triggered reveal animations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build

--- a/app/globals.css
+++ b/app/globals.css
@@ -387,18 +387,20 @@ img {
   display: inline-block;
   opacity: 0;
   transform: translateY(40px);
+}
+.cs-hero.in-view h1 .reveal {
   animation: reveal 1s cubic-bezier(0.22, 0.9, 0.3, 1) forwards;
 }
-.cs-hero h1 .reveal:nth-child(1) {
+.cs-hero.in-view h1 .reveal:nth-child(1) {
   animation-delay: 0.1s;
 }
-.cs-hero h1 .reveal:nth-child(2) {
+.cs-hero.in-view h1 .reveal:nth-child(2) {
   animation-delay: 0.3s;
 }
-.cs-hero h1 .reveal:nth-child(3) {
+.cs-hero.in-view h1 .reveal:nth-child(3) {
   animation-delay: 0.5s;
 }
-.cs-hero h1 .reveal:nth-child(4) {
+.cs-hero.in-view h1 .reveal:nth-child(4) {
   animation-delay: 0.7s;
 }
 @keyframes reveal {
@@ -415,6 +417,8 @@ img {
   line-height: 1.6;
   color: var(--ink-2);
   opacity: 0;
+}
+.cs-hero.in-view .cs-hero-tag {
   animation: reveal 0.9s 0.9s ease forwards;
 }
 
@@ -424,6 +428,8 @@ img {
   gap: 14px;
   flex-wrap: wrap;
   opacity: 0;
+}
+.cs-hero.in-view .cs-hero-cta {
   animation: reveal 0.9s 1.1s ease forwards;
 }
 
@@ -1130,6 +1136,19 @@ img {
   .cs-cursor {
     display: none;
   }
+}
+
+/* scroll-triggered reveal */
+.scroll-reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition:
+    opacity 1s cubic-bezier(0.22, 0.9, 0.3, 1) var(--reveal-delay, 0s),
+    transform 1s cubic-bezier(0.22, 0.9, 0.3, 1) var(--reveal-delay, 0s);
+}
+.scroll-reveal.in-view {
+  opacity: 1;
+  transform: none;
 }
 
 /* page-fade transition */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,96 +1,79 @@
 import Link from 'next/link';
 import PrebuildImage from '@/public/prebuild-1.webp';
 import { services } from '@/lib/services';
-import { siteVersion } from '@/lib/config';
 import SectionLabel from '@/components/cosmos/section-label';
 import GlowFrame from '@/components/cosmos/glow-frame';
 import HomeCarousel from '@/components/sections/carousel';
 import ServiceCards from '@/components/sections/service-cards';
+import ScrollReveal from '@/components/cosmos/scroll-reveal';
+import HeroSection from '@/components/sections/hero-section';
 
 export default function HomePage() {
   return (
     <div className='cs-page cs-fade-in'>
       {/* HERO */}
-      <section className='cs-hero'>
-        <div className='cs-hero-meta'>
-          <span className='cs-hero-meta-dot' />
-          <span>SYSTEM ONLINE — KRK / 50.06°N 19.94°E</span>
-          <span className='cs-hero-meta-line' />
-          <span>{siteVersion}</span>
-        </div>
-        <h1>
-          <span className='reveal'>Składam</span>{' '}
-          <span className='reveal accent'>komputery</span>
-          <br />
-          <span className='reveal'>i&nbsp;tworzę</span>{' '}
-          <span className='reveal accent'>strony</span>
-          <span className='reveal'>.</span>
-        </h1>
-        <p className='cs-hero-tag'>
-          Z Krakowa, dla Ciebie. Dobieram komponenty, składam zestawy,
-          konfiguruję systemy i piszę nowoczesne strony — od pierwszego pomysłu
-          po działający produkt.
-        </p>
-        <div className='cs-hero-cta'>
-          <Link href='/oferta' className='btn-cosmic primary'>
-            Zobacz ofertę <span className='arrow'>→</span>
-          </Link>
-          <Link href='/kontakt' className='btn-cosmic'>
-            Skontaktuj się <span className='arrow'>↗</span>
-          </Link>
-        </div>
-      </section>
+      <HeroSection />
 
       {/* CAROUSEL */}
       <section>
-        <SectionLabel
-          code='// 01'
-          title='Co buduję'
-          kicker='Wybrane usługi w transmisji na żywo'
-        />
-        <HomeCarousel />
+        <ScrollReveal>
+          <SectionLabel
+            code='// 01'
+            title='Co buduję'
+            kicker='Wybrane usługi w transmisji na żywo'
+          />
+        </ScrollReveal>
+        <ScrollReveal delay={0.1}>
+          <HomeCarousel />
+        </ScrollReveal>
       </section>
 
       {/* SERVICES */}
       <section>
-        <SectionLabel
-          code='// 02'
-          title='Pełna oferta'
-          kicker='Cztery moduły, jeden inżynier'
-        />
+        <ScrollReveal>
+          <SectionLabel
+            code='// 02'
+            title='Pełna oferta'
+            kicker='Cztery moduły, jeden inżynier'
+          />
+        </ScrollReveal>
         <ServiceCards services={services} />
       </section>
 
       {/* CALLOUT */}
       <section className='cs-callout'>
-        <GlowFrame
-          src={PrebuildImage}
-          alt='PC z RGB'
-          ratio='4/3'
-          designation='WARNING-001'
-          label='Pre-built risk'
-        />
-        <div className='cs-callout-body'>
-          <h3>
-            Nie kupuj gotowców <em>PC</em>.
-          </h3>
-          <p>
-            Gotowe zestawy komputerowe to często strata pieniędzy. Sklepy
-            montują w nich źle dobrane komponenty, a bardzo często wykorzystują
-            części, które zalegają na magazynie. Efekt? Słabsza wydajność i brak
-            sensownej rozbudowy.
-          </p>
-          <p>
-            Za cenę gotowca złożę komputer znacznie wydajniejszy, idealnie
-            dopasowany do Twoich potrzeb i budżetu. Napisz — doradzę i złożę
-            lepszy zestaw.
-          </p>
-          <div style={{ marginTop: 22 }}>
-            <Link href='/kontakt' className='btn-cosmic primary'>
-              Napisz do mnie <span className='arrow'>→</span>
-            </Link>
+        <ScrollReveal>
+          <GlowFrame
+            src={PrebuildImage}
+            alt='PC z RGB'
+            ratio='4/3'
+            designation='WARNING-001'
+            label='Pre-built risk'
+          />
+        </ScrollReveal>
+        <ScrollReveal delay={0.15}>
+          <div className='cs-callout-body'>
+            <h3>
+              Nie kupuj gotowców <em>PC</em>.
+            </h3>
+            <p>
+              Gotowe zestawy komputerowe to często strata pieniędzy. Sklepy
+              montują w nich źle dobrane komponenty, a bardzo często
+              wykorzystują części, które zalegają na magazynie. Efekt? Słabsza
+              wydajność i brak sensownej rozbudowy.
+            </p>
+            <p>
+              Za cenę gotowca złożę komputer znacznie wydajniejszy, idealnie
+              dopasowany do Twoich potrzeb i budżetu. Napisz — doradzę i złożę
+              lepszy zestaw.
+            </p>
+            <div style={{ marginTop: 22 }}>
+              <Link href='/kontakt' className='btn-cosmic primary'>
+                Napisz do mnie <span className='arrow'>→</span>
+              </Link>
+            </div>
           </div>
-        </div>
+        </ScrollReveal>
       </section>
     </div>
   );

--- a/components/cosmos/scroll-reveal.tsx
+++ b/components/cosmos/scroll-reveal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useInView } from '@/hooks/use-in-view';
+
+type Props = {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+};
+
+export default function ScrollReveal({
+  children,
+  delay = 0,
+  className,
+}: Props) {
+  const { ref, inView } = useInView();
+  return (
+    <div
+      ref={ref as React.RefObject<HTMLDivElement>}
+      className={`scroll-reveal${inView ? ' in-view' : ''}${className ? ` ${className}` : ''}`}
+      style={
+        delay
+          ? ({ '--reveal-delay': `${delay}s` } as React.CSSProperties)
+          : undefined
+      }
+    >
+      {children}
+    </div>
+  );
+}

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Link from 'next/link';
+import { siteVersion } from '@/lib/config';
+import { useInView } from '@/hooks/use-in-view';
+
+export default function HeroSection() {
+  const { ref, inView } = useInView();
+  return (
+    <section
+      ref={ref as React.RefObject<HTMLElement>}
+      className={`cs-hero${inView ? ' in-view' : ''}`}
+    >
+      <div className='cs-hero-meta'>
+        <span className='cs-hero-meta-dot' />
+        <span>SYSTEM ONLINE — KRK / 50.06°N 19.94°E</span>
+        <span className='cs-hero-meta-line' />
+        <span>{siteVersion}</span>
+      </div>
+      <h1>
+        <span className='reveal'>Składam</span>{' '}
+        <span className='reveal accent'>komputery</span>
+        <br />
+        <span className='reveal'>i&nbsp;tworzę</span>{' '}
+        <span className='reveal accent'>strony</span>
+        <span className='reveal'>.</span>
+      </h1>
+      <p className='cs-hero-tag'>
+        Z Krakowa, dla Ciebie. Dobieram komponenty, składam zestawy, konfiguruję
+        systemy i piszę nowoczesne strony — od pierwszego pomysłu po działający
+        produkt.
+      </p>
+      <div className='cs-hero-cta'>
+        <Link href='/oferta' className='btn-cosmic primary'>
+          Zobacz ofertę <span className='arrow'>→</span>
+        </Link>
+        <Link href='/kontakt' className='btn-cosmic'>
+          Skontaktuj się <span className='arrow'>↗</span>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/service-cards.tsx
+++ b/components/sections/service-cards.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import type { Service } from '@/lib/services';
 
@@ -13,14 +14,38 @@ export default function ServiceCards({
   variant = 'preview',
 }: ServiceCardsProps) {
   const detail = variant === 'detail';
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.35 }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <div className='cs-services-grid'>
-      {services.map((s) => (
+    <div ref={gridRef} className='cs-services-grid'>
+      {services.map((s, i) => (
         <div
           key={s.slug}
-          className='cs-service-card'
+          className={`cs-service-card scroll-reveal${inView ? ' in-view' : ''}`}
           data-interactive
-          style={{ minHeight: detail ? 380 : 320 }}
+          style={
+            {
+              '--reveal-delay': `${0.1 + i * 0.1}s`,
+              minHeight: detail ? 380 : 320,
+            } as React.CSSProperties
+          }
           onMouseMove={(e) => {
             const el = e.currentTarget;
             const a = Math.atan2(

--- a/hooks/use-in-view.ts
+++ b/hooks/use-in-view.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useInView(threshold = 0.35) {
+  const ref = useRef<HTMLElement>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return { ref, inView };
+}

--- a/types/images.d.ts
+++ b/types/images.d.ts
@@ -1,0 +1,19 @@
+declare module '*.webp' {
+  const content: import('next/image').StaticImageData;
+  export default content;
+}
+
+declare module '*.jpg' {
+  const content: import('next/image').StaticImageData;
+  export default content;
+}
+
+declare module '*.jpeg' {
+  const content: import('next/image').StaticImageData;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: import('next/image').StaticImageData;
+  export default content;
+}


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (lint, type-check, build on push/PR to main)
- Add scroll-triggered reveal animations to all home page sections via a reusable `ScrollReveal` component and `useInView` hook
- Extract hero section and service cards into dedicated section components