### PR TITLE
feat: improve inquiry form UX

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1128,6 +1128,94 @@ img {
 .cs-inquiry-wrap {
   margin-top: 32px;
   max-width: 600px;
+  margin-inline: auto;
+}
+
+/* Custom service dropdown */
+.cs-select-custom {
+  position: relative;
+}
+
+.cs-select-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  background: oklch(0.06 0.05 var(--theme-hue) / 0.6);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  color: var(--ink-0);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 12px 14px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 200ms;
+}
+
+.cs-select-trigger:focus {
+  border-color: var(--acc);
+  outline: none;
+}
+
+.cs-select-trigger[aria-expanded='true'] {
+  border-color: var(--acc);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.cs-select-placeholder {
+  color: var(--ink-4);
+}
+
+.cs-select-arrow {
+  font-size: 11px;
+  color: var(--ink-3);
+  transition: transform 200ms;
+  flex-shrink: 0;
+}
+
+.cs-select-arrow.open {
+  transform: rotate(180deg);
+}
+
+.cs-select-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  background: oklch(0.08 0.05 var(--theme-hue) / 1);
+  border: 1px solid var(--acc);
+  border-top: none;
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  overflow: hidden;
+}
+
+.cs-select-option {
+  padding: 10px 14px;
+  font-size: 13px;
+  color: var(--ink-0);
+  cursor: pointer;
+  transition: background 150ms;
+}
+
+.cs-select-option:hover {
+  background: oklch(0.13 0.05 var(--theme-hue) / 1);
+}
+
+.cs-select-option.selected {
+  color: var(--acc);
+}
+
+.cs-form-error-link {
+  color: oklch(0.75 0.18 25);
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 /* ───────────  Footer  ─────────── */

--- a/app/kontakt/actions.ts
+++ b/app/kontakt/actions.ts
@@ -28,6 +28,7 @@ export async function submitInquiry(raw: RawSubmission) {
     name: raw.name,
     email: raw.email,
     service: raw.service,
+    topic: raw.topic,
     message: raw.message,
   });
 }

--- a/components/sections/inquiry-form.tsx
+++ b/components/sections/inquiry-form.tsx
@@ -62,6 +62,7 @@ function ServiceDropdown({
               className={`cs-select-option${value === o.value ? ' selected' : ''}`}
               role='option'
               aria-selected={value === o.value}
+              data-interactive
               onClick={() => {
                 onChange(o.value);
                 setIsOpen(false);
@@ -130,6 +131,7 @@ export default function InquiryForm({ defaultService = '' }: Props) {
             type='text'
             className='cs-input'
             placeholder='Jan Kowalski'
+            data-interactive
             required
             minLength={2}
             maxLength={80}
@@ -147,6 +149,7 @@ export default function InquiryForm({ defaultService = '' }: Props) {
             type='email'
             className='cs-input'
             placeholder='jan@example.com'
+            data-interactive
             required
             autoComplete='email'
           />
@@ -171,6 +174,7 @@ export default function InquiryForm({ defaultService = '' }: Props) {
               type='text'
               className='cs-input'
               placeholder='Opisz czego dotyczy zapytanie…'
+              data-interactive
               required
               minLength={2}
               maxLength={200}
@@ -187,6 +191,7 @@ export default function InquiryForm({ defaultService = '' }: Props) {
             name='message'
             className='cs-textarea'
             placeholder='Opisz swój projekt lub pytanie…'
+            data-interactive
             required
             minLength={10}
             maxLength={2000}

--- a/components/sections/inquiry-form.tsx
+++ b/components/sections/inquiry-form.tsx
@@ -1,15 +1,80 @@
 'use client';
 
-import { useActionState } from 'react';
+import { useActionState, useState, useRef, useEffect } from 'react';
 import { submitInquiry } from '@/app/kontakt/actions';
 import ScrollReveal from '@/components/cosmos/scroll-reveal';
 import { services } from '@/lib/services';
+import { siteEmail } from '@/lib/config';
 
 type Props = {
   defaultService?: string;
 };
 
-type FormState = { ok: true } | { ok: false; error: string } | null;
+type FormState =
+  | { ok: true }
+  | { ok: false; error: string; showContact?: boolean }
+  | null;
+
+const serviceOptions = [
+  ...services.map((s) => ({ value: s.slug, label: s.title })),
+  { value: 'inne', label: 'Inne' },
+];
+
+function ServiceDropdown({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, []);
+
+  const selected = serviceOptions.find((o) => o.value === value);
+
+  return (
+    <div className='cs-select-custom' ref={ref}>
+      <button
+        type='button'
+        className={`cs-select-trigger${!selected ? ' cs-select-placeholder' : ''}`}
+        onClick={() => setIsOpen((o) => !o)}
+        aria-haspopup='listbox'
+        aria-expanded={isOpen}
+      >
+        {selected ? selected.label : '— wybierz usługę —'}
+        <span className={`cs-select-arrow${isOpen ? ' open' : ''}`}>▾</span>
+      </button>
+      {isOpen && (
+        <ul className='cs-select-dropdown' role='listbox'>
+          {serviceOptions.map((o) => (
+            <li
+              key={o.value}
+              className={`cs-select-option${value === o.value ? ' selected' : ''}`}
+              role='option'
+              aria-selected={value === o.value}
+              onClick={() => {
+                onChange(o.value);
+                setIsOpen(false);
+              }}
+            >
+              {o.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 function SuccessCard() {
   return (
@@ -24,12 +89,14 @@ function SuccessCard() {
 }
 
 export default function InquiryForm({ defaultService = '' }: Props) {
+  const [selectedService, setSelectedService] = useState(defaultService);
   const [state, formAction, isPending] = useActionState<FormState, FormData>(
     async (_prev, formData) => {
       const payload = {
         name: formData.get('name') as string,
         email: formData.get('email') as string,
         service: formData.get('service') as string,
+        topic: (formData.get('topic') as string) || undefined,
         message: formData.get('message') as string,
         _hp: (formData.get('_hp') as string) ?? '',
       };
@@ -51,6 +118,7 @@ export default function InquiryForm({ defaultService = '' }: Props) {
           style={{ display: 'none' }}
           autoComplete='off'
         />
+        <input type='hidden' name='service' value={selectedService} />
 
         <div className='cs-field'>
           <label htmlFor='inq-name' className='cs-label'>
@@ -85,26 +153,30 @@ export default function InquiryForm({ defaultService = '' }: Props) {
         </div>
 
         <div className='cs-field'>
-          <label htmlFor='inq-service' className='cs-label'>
-            Usługa
-          </label>
-          <select
-            id='inq-service'
-            name='service'
-            className='cs-select'
-            defaultValue={defaultService}
-            required
-          >
-            <option value='' disabled>
-              — wybierz usługę —
-            </option>
-            {services.map((s) => (
-              <option key={s.slug} value={s.slug}>
-                {s.title}
-              </option>
-            ))}
-          </select>
+          <label className='cs-label'>Usługa</label>
+          <ServiceDropdown
+            value={selectedService}
+            onChange={setSelectedService}
+          />
         </div>
+
+        {selectedService === 'inne' && (
+          <div className='cs-field'>
+            <label htmlFor='inq-topic' className='cs-label'>
+              Temat
+            </label>
+            <input
+              id='inq-topic'
+              name='topic'
+              type='text'
+              className='cs-input'
+              placeholder='Opisz czego dotyczy zapytanie…'
+              required
+              minLength={2}
+              maxLength={200}
+            />
+          </div>
+        )}
 
         <div className='cs-field'>
           <label htmlFor='inq-message' className='cs-label'>
@@ -124,14 +196,22 @@ export default function InquiryForm({ defaultService = '' }: Props) {
         {state?.ok === false && (
           <p className='cs-form-error' role='alert'>
             {state.error}
+            {state.showContact && (
+              <>
+                {' '}
+                <a href={`mailto:${siteEmail}`} className='cs-form-error-link'>
+                  {siteEmail}
+                </a>
+              </>
+            )}
           </p>
         )}
 
         <button
           type='submit'
           className='btn-cosmic primary'
-          disabled={isPending}
-          aria-disabled={isPending}
+          disabled={isPending || !selectedService}
+          aria-disabled={isPending || !selectedService}
         >
           {isPending ? 'Wysyłanie…' : 'Wyślij wiadomość →'}
         </button>

--- a/lib/email/inquiry-template.ts
+++ b/lib/email/inquiry-template.ts
@@ -15,20 +15,23 @@ function escapeHtml(s: string) {
 }
 
 export function renderInquiryEmail(payload: InquiryPayload): EmailOutput {
-  const { name, email, service, message } = payload;
+  const { name, email, service, topic, message } = payload;
+
+  const serviceDisplay =
+    service === 'inne' ? `Inne${topic ? ` — ${topic}` : ''}` : service;
 
   const subject = `Nowe zapytanie od ${name}`;
 
   const text = [
     `Od: ${name} <${email}>`,
-    `Usługa: ${service}`,
+    `Usługa: ${serviceDisplay}`,
     ``,
     message,
   ].join('\n');
 
   const html = `
     <p><strong>Od:</strong> ${escapeHtml(name)} &lt;${escapeHtml(email)}&gt;</p>
-    <p><strong>Usługa:</strong> ${escapeHtml(service)}</p>
+    <p><strong>Usługa:</strong> ${escapeHtml(serviceDisplay)}</p>
     <hr />
     <p>${escapeHtml(message).replace(/\n/g, '<br />')}</p>
   `.trim();

--- a/lib/inquiry-schema.ts
+++ b/lib/inquiry-schema.ts
@@ -3,11 +3,19 @@ import { services } from '@/lib/services';
 
 const serviceSlugs = services.map((s) => s.slug) as [string, ...string[]];
 
-export const inquirySchema = z.object({
-  name: z.string().min(2).max(80),
-  email: z.email(),
-  service: z.enum(serviceSlugs),
-  message: z.string().min(10).max(2000),
-});
+export const inquirySchema = z
+  .object({
+    name: z.string().min(2).max(80),
+    email: z.email(),
+    service: z.union([z.enum(serviceSlugs), z.literal('inne')]),
+    topic: z.string().max(200).optional(),
+    message: z.string().min(10).max(2000),
+  })
+  .refine(
+    (data) =>
+      data.service !== 'inne' ||
+      (!!data.topic && data.topic.trim().length >= 2),
+    { message: 'Opisz temat zapytania.', path: ['topic'] }
+  );
 
 export type InquiryPayload = z.infer<typeof inquirySchema>;

--- a/lib/submit-inquiry.ts
+++ b/lib/submit-inquiry.ts
@@ -1,7 +1,9 @@
 import { sendInquiryEmail } from '@/lib/email/send-inquiry';
 import { inquirySchema, type InquiryPayload } from '@/lib/inquiry-schema';
 
-type SubmitResult = { ok: true } | { ok: false; error: string };
+type SubmitResult =
+  | { ok: true }
+  | { ok: false; error: string; showContact?: boolean };
 
 export async function processInquiry(
   payload: InquiryPayload
@@ -17,7 +19,8 @@ export async function processInquiry(
     return {
       ok: false,
       error:
-        'Nie udało się wysłać wiadomości. Spróbuj ponownie lub skontaktuj się bezpośrednio.',
+        'Nie udało się wysłać wiadomości. Spróbuj ponownie lub napisz bezpośrednio na:',
+      showContact: true,
     };
   }
   return { ok: true };


### PR DESCRIPTION
## Summary

- Center form on the contact page (`margin-inline: auto` on `.cs-inquiry-wrap`)
- Add **Inne** option to the service dropdown; selecting it reveals a required **Temat** field so the inquiry still has useful context
- Replace native `<select>` with a custom CSS-only dropdown (div + useState/useRef, no new deps) that matches the existing dark/cosmic theme
- Show a clickable `mailto:` link to `siteEmail` in the send-failure error message so users can always reach out manually

## Test plan

- [ ] Open `/kontakt` — form is horizontally centered on wide screens
- [ ] Open dropdown — custom options list appears with accent border, closes on outside click
- [ ] Select **Inne** — **Temat** field appears and is required; submit blocked until filled
- [ ] Select a normal service — **Temat** field is hidden
- [ ] Submit button is disabled until a service is selected
- [ ] Simulate a send failure — error shows the `mailto:` link to `kris1027.dev@gmail.com`
- [ ] Pre-fill via `?service=tworzenie-stron-internetowych` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)