### PR TITLE
feat: extract reusable components to eliminate code duplication

### DIFF
--- a/app/kontakt/page.tsx
+++ b/app/kontakt/page.tsx
@@ -2,6 +2,7 @@ import { SectionLabel } from '@/components/cosmos/section-label';
 import { InquiryForm } from '@/components/sections/inquiry-form/inquiry-form';
 import { ContactChannels } from '@/components/sections/contact-channels';
 import { services } from '@/lib/services/data';
+import { kontaktContent } from '@/lib/content/kontakt';
 import styles from './page.module.css';
 
 type Props = { searchParams: Promise<{ service?: string }> };
@@ -15,9 +16,9 @@ export default async function KontaktPage({ searchParams }: Props) {
     <div className='cs-page cs-fade-in'>
       <section className={styles.inquirySection}>
         <SectionLabel
-          code='// MSG'
-          title='Wyślij zapytanie'
-          kicker='Opisz swój projekt — odpowiem w ciągu 24 godzin'
+          code={kontaktContent.page.inquiry.code}
+          title={kontaktContent.page.inquiry.title}
+          kicker={kontaktContent.page.inquiry.kicker}
         />
         <div className={styles.inquiryWrap}>
           <InquiryForm defaultService={defaultService} />
@@ -26,9 +27,9 @@ export default async function KontaktPage({ searchParams }: Props) {
 
       <section>
         <SectionLabel
-          code='// 04'
-          title='Kontakt'
-          kicker='Otwórz kanał komunikacji — odpowiem szybko'
+          code={kontaktContent.page.contact.code}
+          title={kontaktContent.page.contact.title}
+          kicker={kontaktContent.page.contact.kicker}
         />
         <ContactChannels />
       </section>

--- a/app/kontakt/page.tsx
+++ b/app/kontakt/page.tsx
@@ -13,15 +13,6 @@ export default async function KontaktPage({ searchParams }: Props) {
 
   return (
     <div className='cs-page cs-fade-in'>
-      <section>
-        <SectionLabel
-          code='// 04'
-          title='Kontakt'
-          kicker='Otwórz kanał komunikacji — odpowiem szybko'
-        />
-        <ContactChannels />
-      </section>
-
       <section className={styles.inquirySection}>
         <SectionLabel
           code='// MSG'
@@ -31,6 +22,15 @@ export default async function KontaktPage({ searchParams }: Props) {
         <div className={styles.inquiryWrap}>
           <InquiryForm defaultService={defaultService} />
         </div>
+      </section>
+
+      <section>
+        <SectionLabel
+          code='// 04'
+          title='Kontakt'
+          kicker='Otwórz kanał komunikacji — odpowiem szybko'
+        />
+        <ContactChannels />
       </section>
     </div>
   );

--- a/app/o-mnie/page.tsx
+++ b/app/o-mnie/page.tsx
@@ -2,70 +2,37 @@ import Image from 'next/image';
 import ProfileImage from '@/public/profile-1.webp';
 import { SectionLabel } from '@/components/cosmos/section-label';
 import { githubUrl, linkedinUrl } from '@/lib/config';
+import { aboutContent } from '@/lib/content/about';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import { SocialLink } from '@/components/cosmos/social-link';
 import styles from './page.module.css';
-
-const TECHNOLOGIES: [string, string[]][] = [
-  [
-    'Frontend',
-    [
-      'HTML5',
-      'CSS3',
-      'JavaScript',
-      'TypeScript',
-      'Next.js',
-      'Astro',
-      'TailwindCSS',
-      'shadcn/ui',
-      'SCSS',
-      'TanStack',
-    ],
-  ],
-  ['Mobile', ['React Native', 'Expo', 'Telegram Mini Apps']],
-  ['Backend', ['Node.js', 'NestJS', 'Express', 'Swagger', 'JWT']],
-  ['Bazy', ['PostgreSQL', 'MongoDB', 'Prisma', 'Supabase', 'Firebase']],
-  ['Web3', ['Ethers.js', 'Web3']],
-  [
-    'Testy',
-    ['Jest', 'Cypress', 'Supertest', 'React Testing Library', 'Playwright'],
-  ],
-  ['DevOps', ['Git', 'Docker', 'Grafana', 'Prometheus']],
-  [
-    'Edytory',
-    [
-      'Codex',
-      'Claude Code',
-      'Cursor',
-      'GitHub Copilot',
-      'VS Code',
-      'Neovim',
-      'WebStorm',
-    ],
-  ],
-];
 
 export default function AboutPage() {
   return (
     <div className='cs-page cs-fade-in'>
       <section>
         <SectionLabel
-          code='// 02'
-          title='O mnie'
-          kicker='// transmisja osobista'
+          code={aboutContent.section.code}
+          title={aboutContent.section.title}
+          kicker={aboutContent.section.kicker}
         />
         <div className={styles.aboutGrid}>
           <div className={styles.portrait}>
             <div className={styles.ring} />
             <div className={styles.ring} />
             <div className={styles.photo}>
-              <Image src={ProfileImage} alt='Krzysztof' fill sizes='240px' />
+              <Image
+                src={ProfileImage}
+                alt={aboutContent.profile.imageAlt}
+                fill
+                sizes='240px'
+              />
             </div>
           </div>
           <div className={styles.body}>
-            <div className={styles.role}>{'// inżynier · krk'}</div>
-            <div className={styles.name}>Krzysztof Obarzanek</div>
+            <div className={styles.role}>{aboutContent.profile.role}</div>
+            <div className={styles.name}>{aboutContent.profile.name}</div>
             <div className={styles.socialLinks}>
               <SocialLink
                 href={githubUrl}
@@ -82,17 +49,13 @@ export default function AboutPage() {
                 className={styles.socialBtn}
               />
             </div>
-            <p className={styles.bio}>
-              Jestem pasjonatem technologii, który kocha doradzać w doborze
-              sprzętu, składać komputery i tworzyć strony internetowe. Moja
-              pasja do technologii napędza mnie do nieustannego doskonalenia
-              swoich umiejętności i tworzenia rozwiązań, które łączą innowację z
-              praktycznością.
-            </p>
+            <p className={styles.bio}>{aboutContent.profile.bio}</p>
             <div className={styles.bodyBtns}>
-              <CosmicButton href='/oferta'>Zobacz ofertę</CosmicButton>
+              <CosmicButton href='/oferta'>
+                {aboutContent.profile.btns.oferta}
+              </CosmicButton>
               <CosmicButton href='/kontakt' arrow='↗'>
-                Kontakt
+                {aboutContent.profile.btns.kontakt}
               </CosmicButton>
             </div>
           </div>
@@ -101,12 +64,12 @@ export default function AboutPage() {
 
       <section>
         <SectionLabel
-          code='// tech'
-          title='Technologie'
-          kicker='Narzędzia, z których korzystam w pracy'
+          code={aboutContent.tech.code}
+          title={aboutContent.tech.title}
+          kicker={aboutContent.tech.kicker}
         />
         <div className={styles.techGrid}>
-          {TECHNOLOGIES.map(([cat, items]) => (
+          {aboutContent.technologies.map(([cat, items]) => (
             <div key={cat} className={styles.techCat}>
               <div className={styles.techCatName}>{cat}</div>
               <ul>

--- a/app/o-mnie/page.tsx
+++ b/app/o-mnie/page.tsx
@@ -3,6 +3,7 @@ import ProfileImage from '@/public/profile-1.webp';
 import { SectionLabel } from '@/components/cosmos/section-label';
 import { githubUrl, linkedinUrl } from '@/lib/config';
 import { aboutContent } from '@/lib/content/about';
+import { sharedContent } from '@/lib/content/shared';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import { SocialLink } from '@/components/cosmos/social-link';
@@ -52,10 +53,10 @@ export default function AboutPage() {
             <p className={styles.bio}>{aboutContent.profile.bio}</p>
             <div className={styles.bodyBtns}>
               <CosmicButton href='/oferta'>
-                {aboutContent.profile.btns.oferta}
+                {sharedContent.cta.seeOffer}
               </CosmicButton>
               <CosmicButton href='/kontakt' arrow='↗'>
-                {aboutContent.profile.btns.kontakt}
+                {aboutContent.profile.btnKontakt}
               </CosmicButton>
             </div>
           </div>

--- a/app/o-mnie/page.tsx
+++ b/app/o-mnie/page.tsx
@@ -4,6 +4,7 @@ import { SectionLabel } from '@/components/cosmos/section-label';
 import { githubUrl, linkedinUrl } from '@/lib/config';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
+import { SocialLink } from '@/components/cosmos/social-link';
 import styles from './page.module.css';
 
 const TECHNOLOGIES: [string, string[]][] = [
@@ -66,24 +67,20 @@ export default function AboutPage() {
             <div className={styles.role}>{'// inżynier · krk'}</div>
             <div className={styles.name}>Krzysztof Obarzanek</div>
             <div className={styles.socialLinks}>
-              <a
+              <SocialLink
                 href={githubUrl}
-                target='_blank'
-                rel='noopener noreferrer'
+                icon={<GithubIcon />}
+                label='GitHub'
+                showLabel
                 className={styles.socialBtn}
-              >
-                <GithubIcon />
-                GitHub
-              </a>
-              <a
+              />
+              <SocialLink
                 href={linkedinUrl}
-                target='_blank'
-                rel='noopener noreferrer'
+                icon={<LinkedinIcon />}
+                label='LinkedIn'
+                showLabel
                 className={styles.socialBtn}
-              >
-                <LinkedinIcon />
-                LinkedIn
-              </a>
+              />
             </div>
             <p className={styles.bio}>
               Jestem pasjonatem technologii, który kocha doradzać w doborze

--- a/app/o-mnie/page.tsx
+++ b/app/o-mnie/page.tsx
@@ -1,9 +1,9 @@
 import Image from 'next/image';
 import ProfileImage from '@/public/profile-1.webp';
 import { SectionLabel } from '@/components/cosmos/section-label';
-import Link from 'next/link';
 import { githubUrl, linkedinUrl } from '@/lib/config';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './page.module.css';
 
 const TECHNOLOGIES: [string, string[]][] = [
@@ -93,12 +93,10 @@ export default function AboutPage() {
               praktycznością.
             </p>
             <div className={styles.bodyBtns}>
-              <Link href='/oferta' className='btn-cosmic'>
-                Zobacz ofertę <span className='arrow'>→</span>
-              </Link>
-              <Link href='/kontakt' className='btn-cosmic'>
-                Kontakt <span className='arrow'>↗</span>
-              </Link>
+              <CosmicButton href='/oferta'>Zobacz ofertę</CosmicButton>
+              <CosmicButton href='/kontakt' arrow='↗'>
+                Kontakt
+              </CosmicButton>
             </div>
           </div>
         </div>

--- a/app/oferta/[slug]/page.tsx
+++ b/app/oferta/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { services } from '@/lib/services/data';
+import { ofertaContent } from '@/lib/content/oferta';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -31,7 +32,7 @@ export default async function ServiceDetailPage({ params }: Props) {
     <div className='cs-page cs-fade-in'>
       <section>
         <Link href='/oferta' className={styles.breadcrumb}>
-          ← <span>Oferta</span> /{' '}
+          ← <span>{ofertaContent.detail.breadcrumb}</span> /{' '}
           <span className={styles.breadcrumbCurrent}>{s.designation}</span>
         </Link>
 
@@ -45,11 +46,15 @@ export default async function ServiceDetailPage({ params }: Props) {
             <p className={styles.lead}>{s.shortDescription}</p>
             <div className={styles.meta}>
               <div>
-                <div className={styles.metaKey}>{'// czas realizacji'}</div>
+                <div className={styles.metaKey}>
+                  {ofertaContent.detail.meta.timeKey}
+                </div>
                 <div className={styles.metaVal}>{s.timeNote}</div>
               </div>
               <div>
-                <div className={styles.metaKey}>{'// rozliczenie'}</div>
+                <div className={styles.metaKey}>
+                  {ofertaContent.detail.meta.pricingKey}
+                </div>
                 <div className={styles.metaVal}>{s.pricingNote}</div>
               </div>
             </div>
@@ -58,10 +63,10 @@ export default async function ServiceDetailPage({ params }: Props) {
                 href={`/kontakt?service=${s.slug}`}
                 variant='primary'
               >
-                Zapytaj o tę usługę
+                {ofertaContent.detail.btns.inquire}
               </CosmicButton>
               <CosmicButton href='/oferta' arrow='↗'>
-                Wszystkie usługi
+                {ofertaContent.detail.btns.allServices}
               </CosmicButton>
             </div>
           </div>
@@ -80,9 +85,9 @@ export default async function ServiceDetailPage({ params }: Props) {
 
       <section>
         <SectionLabel
-          code='// opis'
-          title='Co dostajesz'
-          kicker='Pełny zakres tej usługi'
+          code={ofertaContent.detail.sections.opis.code}
+          title={ofertaContent.detail.sections.opis.title}
+          kicker={ofertaContent.detail.sections.opis.kicker}
         />
         <p className={styles.longDescription}>{s.longDescription}</p>
         <ul className={styles.features}>
@@ -94,9 +99,9 @@ export default async function ServiceDetailPage({ params }: Props) {
 
       <section>
         <SectionLabel
-          code='// proces'
-          title='Jak pracuję'
-          kicker='Krok po kroku, bez niespodzianek'
+          code={ofertaContent.detail.sections.proces.code}
+          title={ofertaContent.detail.sections.proces.title}
+          kicker={ofertaContent.detail.sections.proces.kicker}
         />
         <ol className={styles.process}>
           {s.process.map(([n, t, d]) => (
@@ -113,9 +118,9 @@ export default async function ServiceDetailPage({ params }: Props) {
 
       <section>
         <SectionLabel
-          code='// efekt'
-          title='Co dostajesz na koniec'
-          kicker='Konkretne deliverables'
+          code={ofertaContent.detail.sections.efekt.code}
+          title={ofertaContent.detail.sections.efekt.title}
+          kicker={ofertaContent.detail.sections.efekt.kicker}
         />
         <div className={styles.deliverables}>
           {s.deliverables.map((d, i) => (
@@ -129,19 +134,18 @@ export default async function ServiceDetailPage({ params }: Props) {
 
       <section className={styles.cta}>
         <div>
-          <div className={styles.ctaKicker}>{'// gotowy?'}</div>
-          <h3>Otwórz kanał komunikacji.</h3>
-          <p>
-            Napisz krótko czego potrzebujesz — odpiszę najczęściej tego samego
-            dnia z konkretną wyceną i terminem.
-          </p>
+          <div className={styles.ctaKicker}>
+            {ofertaContent.detail.cta.kicker}
+          </div>
+          <h3>{ofertaContent.detail.cta.heading}</h3>
+          <p>{ofertaContent.detail.cta.body}</p>
         </div>
         <div className={styles.ctaBtns}>
           <CosmicButton href={`/kontakt?service=${s.slug}`} variant='primary'>
-            Skontaktuj się
+            {ofertaContent.detail.cta.primary}
           </CosmicButton>
           <CosmicButton href={`/oferta/${next.slug}`} arrow='↗'>
-            Następna: {next.designation}
+            {ofertaContent.detail.cta.next} {next.designation}
           </CosmicButton>
         </div>
       </section>

--- a/app/oferta/[slug]/page.tsx
+++ b/app/oferta/[slug]/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { SectionLabel } from '@/components/cosmos/section-label';
 import { GlowFrame } from '@/components/cosmos/glow-frame';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './page.module.css';
 
 type Props = { params: Promise<{ slug: string }> };
@@ -53,15 +54,15 @@ export default async function ServiceDetailPage({ params }: Props) {
               </div>
             </div>
             <div className={styles.heroBtns}>
-              <Link
+              <CosmicButton
                 href={`/kontakt?service=${s.slug}`}
-                className='btn-cosmic primary'
+                variant='primary'
               >
-                Zapytaj o tę usługę <span className='arrow'>→</span>
-              </Link>
-              <Link href='/oferta' className='btn-cosmic'>
-                Wszystkie usługi <span className='arrow'>↗</span>
-              </Link>
+                Zapytaj o tę usługę
+              </CosmicButton>
+              <CosmicButton href='/oferta' arrow='↗'>
+                Wszystkie usługi
+              </CosmicButton>
             </div>
           </div>
           <div className={styles.heroImg}>
@@ -136,15 +137,12 @@ export default async function ServiceDetailPage({ params }: Props) {
           </p>
         </div>
         <div className={styles.ctaBtns}>
-          <Link
-            href={`/kontakt?service=${s.slug}`}
-            className='btn-cosmic primary'
-          >
-            Skontaktuj się <span className='arrow'>→</span>
-          </Link>
-          <Link href={`/oferta/${next.slug}`} className='btn-cosmic'>
-            Następna: {next.designation} <span className='arrow'>↗</span>
-          </Link>
+          <CosmicButton href={`/kontakt?service=${s.slug}`} variant='primary'>
+            Skontaktuj się
+          </CosmicButton>
+          <CosmicButton href={`/oferta/${next.slug}`} arrow='↗'>
+            Następna: {next.designation}
+          </CosmicButton>
         </div>
       </section>
     </div>

--- a/app/oferta/page.tsx
+++ b/app/oferta/page.tsx
@@ -1,4 +1,5 @@
 import { services } from '@/lib/services/data';
+import { ofertaContent } from '@/lib/content/oferta';
 import { SectionLabel } from '@/components/cosmos/section-label';
 import { ServiceCards } from '@/components/sections/service-cards';
 
@@ -7,9 +8,9 @@ export default function OfertaPage() {
     <div className='cs-page cs-fade-in'>
       <section>
         <SectionLabel
-          code='// 03'
-          title='Oferta'
-          kicker='Cztery moduły gotowe do uruchomienia'
+          code={ofertaContent.page.code}
+          title={ofertaContent.page.title}
+          kicker={ofertaContent.page.kicker}
         />
         <ServiceCards services={services} variant='detail' />
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,8 +50,8 @@ export default function HomePage() {
         <ScrollReveal delay={0.15}>
           <div className={styles.calloutBody}>
             <h3>
-              {homeContent.callout.heading}{' '}
-              <em>{homeContent.callout.headingEmphasis}</em>.
+              {homeContent.callout.heading.before}{' '}
+              <em>{homeContent.callout.heading.em}</em>.
             </h3>
             <p>{homeContent.callout.body1}</p>
             <p>{homeContent.callout.body2}</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import PrebuildImage from '@/public/prebuild-1.webp';
 import { services } from '@/lib/services/data';
 import { SectionLabel } from '@/components/cosmos/section-label';
@@ -7,6 +6,7 @@ import { HomeCarousel } from '@/components/sections/carousel';
 import { ServiceCards } from '@/components/sections/service-cards';
 import { ScrollReveal } from '@/components/cosmos/scroll-reveal';
 import { HeroSection } from '@/components/sections/hero-section';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './page.module.css';
 
 export default function HomePage() {
@@ -63,9 +63,9 @@ export default function HomePage() {
               lepszy zestaw.
             </p>
             <div className={styles.calloutCta}>
-              <Link href='/kontakt' className='btn-cosmic primary'>
-                Napisz do mnie <span className='arrow'>→</span>
-              </Link>
+              <CosmicButton href='/kontakt' variant='primary'>
+                Napisz do mnie
+              </CosmicButton>
             </div>
           </div>
         </ScrollReveal>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import PrebuildImage from '@/public/prebuild-1.webp';
 import { services } from '@/lib/services/data';
+import { homeContent } from '@/lib/content/home';
 import { SectionLabel } from '@/components/cosmos/section-label';
 import { GlowFrame } from '@/components/cosmos/glow-frame';
 import { HomeCarousel } from '@/components/sections/carousel';
@@ -17,9 +18,9 @@ export default function HomePage() {
       <section>
         <ScrollReveal>
           <SectionLabel
-            code='// 01'
-            title='Co buduję'
-            kicker='Wybrane usługi w transmisji na żywo'
+            code={homeContent.carousel.code}
+            title={homeContent.carousel.title}
+            kicker={homeContent.carousel.kicker}
           />
         </ScrollReveal>
         <HomeCarousel />
@@ -28,9 +29,9 @@ export default function HomePage() {
       <section>
         <ScrollReveal>
           <SectionLabel
-            code='// 02'
-            title='Pełna oferta'
-            kicker='Cztery moduły, jeden inżynier'
+            code={homeContent.oferta.code}
+            title={homeContent.oferta.title}
+            kicker={homeContent.oferta.kicker}
           />
         </ScrollReveal>
         <ServiceCards services={services} />
@@ -40,7 +41,7 @@ export default function HomePage() {
         <ScrollReveal>
           <GlowFrame
             src={PrebuildImage}
-            alt='PC z RGB'
+            alt={homeContent.callout.imageAlt}
             ratio='4/3'
             designation='WARNING-001'
             label='Pre-built risk'
@@ -49,22 +50,14 @@ export default function HomePage() {
         <ScrollReveal delay={0.15}>
           <div className={styles.calloutBody}>
             <h3>
-              Nie kupuj gotowców <em>PC</em>.
+              {homeContent.callout.heading}{' '}
+              <em>{homeContent.callout.headingEmphasis}</em>.
             </h3>
-            <p>
-              Gotowe zestawy komputerowe to często strata pieniędzy. Sklepy
-              montują w nich źle dobrane komponenty, a bardzo często
-              wykorzystują części, które zalegają na magazynie. Efekt? Słabsza
-              wydajność i brak sensownej rozbudowy.
-            </p>
-            <p>
-              Za cenę gotowca złożę komputer znacznie wydajniejszy, idealnie
-              dopasowany do Twoich potrzeb i budżetu. Napisz — doradzę i złożę
-              lepszy zestaw.
-            </p>
+            <p>{homeContent.callout.body1}</p>
+            <p>{homeContent.callout.body2}</p>
             <div className={styles.calloutCta}>
               <CosmicButton href='/kontakt' variant='primary'>
-                Napisz do mnie
+                {homeContent.callout.cta}
               </CosmicButton>
             </div>
           </div>

--- a/components/cosmos/cosmic-button.tsx
+++ b/components/cosmos/cosmic-button.tsx
@@ -1,14 +1,20 @@
 import Link from 'next/link';
 
-type CosmicButtonProps = {
-  href?: string;
+type BaseProps = {
   variant?: 'primary' | 'default';
   arrow?: '→' | '↗' | false;
   className?: string;
-  disabled?: boolean;
-  type?: 'submit' | 'button';
   children: React.ReactNode;
 };
+
+type LinkProps = BaseProps & { href: string; disabled?: never; type?: never };
+type ButtonProps = BaseProps & {
+  href?: never;
+  disabled?: boolean;
+  type?: 'submit' | 'button';
+};
+
+type CosmicButtonProps = LinkProps | ButtonProps;
 
 export function CosmicButton({
   href,

--- a/components/cosmos/cosmic-button.tsx
+++ b/components/cosmos/cosmic-button.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 type CosmicButtonProps = {
   href?: string;
   variant?: 'primary' | 'default';
-  arrow?: '→' | '↗';
+  arrow?: '→' | '↗' | false;
   className?: string;
   disabled?: boolean;
   type?: 'submit' | 'button';
@@ -24,7 +24,13 @@ export function CosmicButton({
   if (href) {
     return (
       <Link href={href} className={cls}>
-        {children} <span className='arrow'>{arrow}</span>
+        {children}
+        {arrow && (
+          <>
+            {' '}
+            <span className='arrow'>{arrow}</span>
+          </>
+        )}
       </Link>
     );
   }
@@ -36,7 +42,13 @@ export function CosmicButton({
       disabled={disabled}
       aria-disabled={disabled}
     >
-      {children} <span className='arrow'>{arrow}</span>
+      {children}
+      {arrow && (
+        <>
+          {' '}
+          <span className='arrow'>{arrow}</span>
+        </>
+      )}
     </button>
   );
 }

--- a/components/cosmos/cosmic-button.tsx
+++ b/components/cosmos/cosmic-button.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+type CosmicButtonProps = {
+  href?: string;
+  variant?: 'primary' | 'default';
+  arrow?: '→' | '↗';
+  className?: string;
+  disabled?: boolean;
+  type?: 'submit' | 'button';
+  children: React.ReactNode;
+};
+
+export function CosmicButton({
+  href,
+  variant = 'default',
+  arrow = '→',
+  className,
+  disabled,
+  type = 'button',
+  children,
+}: CosmicButtonProps) {
+  const cls = `btn-cosmic${variant === 'primary' ? ' primary' : ''}${className ? ` ${className}` : ''}`;
+
+  if (href) {
+    return (
+      <Link href={href} className={cls}>
+        {children} <span className='arrow'>{arrow}</span>
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type={type}
+      className={cls}
+      disabled={disabled}
+      aria-disabled={disabled}
+    >
+      {children} <span className='arrow'>{arrow}</span>
+    </button>
+  );
+}

--- a/components/cosmos/site-location.tsx
+++ b/components/cosmos/site-location.tsx
@@ -1,0 +1,5 @@
+type Props = { className?: string };
+
+export function SiteLocation({ className }: Props) {
+  return <span className={className}>50.0647° N · 19.9450° E · Kraków</span>;
+}

--- a/components/cosmos/site-location.tsx
+++ b/components/cosmos/site-location.tsx
@@ -1,5 +1,7 @@
+import { siteCoords } from '@/lib/config';
+
 type Props = { className?: string };
 
 export function SiteLocation({ className }: Props) {
-  return <span className={className}>50.0647° N · 19.9450° E</span>;
+  return <div className={className}>{siteCoords}</div>;
 }

--- a/components/cosmos/site-location.tsx
+++ b/components/cosmos/site-location.tsx
@@ -1,5 +1,5 @@
 type Props = { className?: string };
 
 export function SiteLocation({ className }: Props) {
-  return <span className={className}>50.0647° N · 19.9450° E · Kraków</span>;
+  return <span className={className}>50.0647° N · 19.9450° E</span>;
 }

--- a/components/cosmos/social-link.tsx
+++ b/components/cosmos/social-link.tsx
@@ -1,0 +1,28 @@
+type SocialLinkProps = {
+  href: string;
+  icon: React.ReactNode;
+  label: string;
+  showLabel?: boolean;
+  className?: string;
+};
+
+export function SocialLink({
+  href,
+  icon,
+  label,
+  showLabel = false,
+  className,
+}: SocialLinkProps) {
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      className={className}
+      aria-label={showLabel ? undefined : label}
+    >
+      {icon}
+      {showLabel && label}
+    </a>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -6,6 +6,7 @@ import {
   siteVersion,
   githubUrl,
   linkedinUrl,
+  siteCoords,
 } from '@/lib/config';
 import { navLinks } from '@/lib/nav';
 import { BrandMark } from '@/components/cosmos/brand-mark';
@@ -59,9 +60,9 @@ export function Footer() {
             />
           </div>
           <div className={styles.coord}>
-            <div>50.0647° N</div>
-            <div>19.9450° E</div>
-            <div className={styles.coordSub}>{'// Kraków'}</div>
+            <div>{siteCoords.lat}</div>
+            <div>{siteCoords.lng}</div>
+            <div className={styles.coordSub}>{'// ' + siteCoords.city}</div>
           </div>
         </div>
       </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -8,6 +8,7 @@ import {
   linkedinUrl,
 } from '@/lib/config';
 import { navLinks } from '@/lib/nav';
+import { layoutContent } from '@/lib/content/layout';
 import { BrandMark } from '@/components/cosmos/brand-mark';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
 import { SocialLink } from '@/components/cosmos/social-link';
@@ -19,7 +20,7 @@ export function Footer() {
     <footer className={styles.footer}>
       <div className={styles.grid}>
         <div>
-          <div className={styles.heading}>{'// nawigacja'}</div>
+          <div className={styles.heading}>{layoutContent.footer.nav}</div>
           {navLinks.map((l) => (
             <Link key={l.href} href={l.href} className={styles.link}>
               <span className={styles.arrow}>↗</span> {l.label}
@@ -27,7 +28,7 @@ export function Footer() {
           ))}
         </div>
         <div>
-          <div className={styles.heading}>{'// oferta'}</div>
+          <div className={styles.heading}>{layoutContent.footer.oferta}</div>
           {services.map((s) => (
             <Link key={s.slug} href='/oferta' className={styles.link}>
               <span className={styles.arrow}>↗</span> {s.title}
@@ -35,7 +36,7 @@ export function Footer() {
           ))}
         </div>
         <div>
-          <div className={styles.heading}>{'// kontakt'}</div>
+          <div className={styles.heading}>{layoutContent.footer.kontakt}</div>
           <a className={styles.link} href={`mailto:${siteEmail}`}>
             <span className={styles.arrow}>↗</span> {siteEmail}
           </a>
@@ -61,15 +62,19 @@ export function Footer() {
           </div>
           <div className={styles.coord}>
             <SiteLocation />
-            <div className={styles.coordSub}>{'// Kraków'}</div>
+            <div className={styles.coordSub}>
+              {layoutContent.footer.location}
+            </div>
           </div>
         </div>
       </div>
       <div className={styles.bottom}>
         <BrandMark size={20} animated={false} />
-        <span>© {new Date().getFullYear()} zaruszaj.pl</span>
+        <span>
+          © {new Date().getFullYear()} {layoutContent.footer.copyright}
+        </span>
         <span className={styles.blink}>●</span>
-        <span>SYS_LINK STABLE</span>
+        <span>{layoutContent.footer.status}</span>
         <span className={styles.spacer} />
         <span>{siteVersion}</span>
       </div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -10,6 +10,7 @@ import {
 import { navLinks } from '@/lib/nav';
 import { BrandMark } from '@/components/cosmos/brand-mark';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
+import { SocialLink } from '@/components/cosmos/social-link';
 import styles from './footer.module.css';
 
 export function Footer() {
@@ -44,24 +45,18 @@ export function Footer() {
             <span className={styles.arrow}>↗</span> {sitePhone}
           </a>
           <div className={styles.socials}>
-            <a
+            <SocialLink
               href={githubUrl}
-              target='_blank'
-              rel='noopener noreferrer'
+              icon={<GithubIcon />}
+              label='GitHub'
               className={styles.socialIcon}
-              aria-label='GitHub'
-            >
-              <GithubIcon />
-            </a>
-            <a
+            />
+            <SocialLink
               href={linkedinUrl}
-              target='_blank'
-              rel='noopener noreferrer'
+              icon={<LinkedinIcon />}
+              label='LinkedIn'
               className={styles.socialIcon}
-              aria-label='LinkedIn'
-            >
-              <LinkedinIcon />
-            </a>
+            />
           </div>
           <div className={styles.coord}>
             <div>50.0647° N</div>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -59,7 +59,10 @@ export function Footer() {
               className={styles.socialIcon}
             />
           </div>
-          <SiteLocation className={styles.coord} />
+          <div className={styles.coord}>
+            <SiteLocation />
+            <div className={styles.coordSub}>{'// Kraków'}</div>
+          </div>
         </div>
       </div>
       <div className={styles.bottom}>

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -6,12 +6,12 @@ import {
   siteVersion,
   githubUrl,
   linkedinUrl,
-  siteCoords,
 } from '@/lib/config';
 import { navLinks } from '@/lib/nav';
 import { BrandMark } from '@/components/cosmos/brand-mark';
 import { GithubIcon, LinkedinIcon } from '@/components/cosmos/icons';
 import { SocialLink } from '@/components/cosmos/social-link';
+import { SiteLocation } from '@/components/cosmos/site-location';
 import styles from './footer.module.css';
 
 export function Footer() {
@@ -59,11 +59,7 @@ export function Footer() {
               className={styles.socialIcon}
             />
           </div>
-          <div className={styles.coord}>
-            <div>{siteCoords.lat}</div>
-            <div>{siteCoords.lng}</div>
-            <div className={styles.coordSub}>{'// ' + siteCoords.city}</div>
-          </div>
+          <SiteLocation className={styles.coord} />
         </div>
       </div>
       <div className={styles.bottom}>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -12,6 +12,28 @@ function isActive(pathname: string, href: string): boolean {
   return pathname === href || pathname.startsWith(href + '/');
 }
 
+type NavLinkProps = {
+  href: string;
+  code: string;
+  label: string;
+  active: boolean;
+  onClick?: () => void;
+};
+
+function NavLink({ href, code, label, active, onClick }: NavLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={`${styles.navLink}${active ? ` ${styles.navLinkActive}` : ''}`}
+      onClick={onClick}
+    >
+      <span className={styles.navCode}>{code}</span>
+      <span>{label}</span>
+      {active && <span className={styles.navDot} />}
+    </Link>
+  );
+}
+
 export function Header() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
@@ -32,20 +54,9 @@ export function Header() {
         </Link>
 
         <nav className={styles.nav}>
-          {navLinks.map((l) => {
-            const active = isActive(pathname, l.href);
-            return (
-              <Link
-                key={l.href}
-                href={l.href}
-                className={`${styles.navLink}${active ? ` ${styles.navLinkActive}` : ''}`}
-              >
-                <span className={styles.navCode}>{l.code}</span>
-                <span>{l.label}</span>
-                {active && <span className={styles.navDot} />}
-              </Link>
-            );
-          })}
+          {navLinks.map((l) => (
+            <NavLink key={l.href} {...l} active={isActive(pathname, l.href)} />
+          ))}
         </nav>
 
         <button
@@ -62,15 +73,12 @@ export function Header() {
       {open && (
         <div className={styles.navMobile}>
           {navLinks.map((l) => (
-            <Link
+            <NavLink
               key={l.href}
-              href={l.href}
-              className={`${styles.navLink}${isActive(pathname, l.href) ? ` ${styles.navLinkActive}` : ''}`}
+              {...l}
+              active={isActive(pathname, l.href)}
               onClick={() => setOpen(false)}
-            >
-              <span className={styles.navCode}>{l.code}</span>
-              <span>{l.label}</span>
-            </Link>
+            />
           ))}
         </div>
       )}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import { BrandMark } from '@/components/cosmos/brand-mark';
 import { navLinks } from '@/lib/nav';
+import { layoutContent } from '@/lib/content/layout';
 import styles from './header.module.css';
 
 function isActive(pathname: string, href: string): boolean {
@@ -53,10 +54,13 @@ export function Header() {
           <BrandMark size={52} animated />
           <span className={styles.brandText}>
             <span className={styles.brandName}>
-              zaruszaj<span className={styles.brandAccent}>.pl</span>
+              {layoutContent.header.brandName}
+              <span className={styles.brandAccent}>
+                {layoutContent.header.brandAccent}
+              </span>
             </span>
             <span className={styles.brandSub}>
-              {'// pc.builds × code.deploy ── KRK'}
+              {layoutContent.header.brandSub}
             </span>
           </span>
         </Link>

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -17,10 +17,18 @@ type NavLinkProps = {
   code: string;
   label: string;
   active: boolean;
+  showDot?: boolean;
   onClick?: () => void;
 };
 
-function NavLink({ href, code, label, active, onClick }: NavLinkProps) {
+function NavLink({
+  href,
+  code,
+  label,
+  active,
+  showDot,
+  onClick,
+}: NavLinkProps) {
   return (
     <Link
       href={href}
@@ -29,7 +37,7 @@ function NavLink({ href, code, label, active, onClick }: NavLinkProps) {
     >
       <span className={styles.navCode}>{code}</span>
       <span>{label}</span>
-      {active && <span className={styles.navDot} />}
+      {active && showDot && <span className={styles.navDot} />}
     </Link>
   );
 }
@@ -55,7 +63,12 @@ export function Header() {
 
         <nav className={styles.nav}>
           {navLinks.map((l) => (
-            <NavLink key={l.href} {...l} active={isActive(pathname, l.href)} />
+            <NavLink
+              key={l.href}
+              {...l}
+              active={isActive(pathname, l.href)}
+              showDot
+            />
           ))}
         </nav>
 

--- a/components/sections/contact-channels.tsx
+++ b/components/sections/contact-channels.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { siteEmail, sitePhone } from '@/lib/config';
+import { kontaktContent } from '@/lib/content/kontakt';
 import { SiteLocation } from '@/components/cosmos/site-location';
 import styles from './contact-channels.module.css';
 
@@ -21,18 +22,18 @@ function LocationIcon() {
 
 const CONTACTS = [
   {
-    label: 'Email',
+    label: kontaktContent.channels.email.label,
     value: siteEmail,
     href: `mailto:${siteEmail}`,
     glyph: '✉',
-    actionLabel: 'NAPISZ',
+    actionLabel: kontaktContent.channels.email.actionLabel,
   },
   {
-    label: 'Telefon / WhatsApp',
+    label: kontaktContent.channels.phone.label,
     value: sitePhone,
     href: `tel:${sitePhone.replace(/\s/g, '')}`,
     glyph: '☎',
-    actionLabel: 'ZADZWOŃ',
+    actionLabel: kontaktContent.channels.phone.actionLabel,
   },
 ];
 
@@ -68,7 +69,9 @@ export function ContactChannels() {
                 className={styles.btn}
                 onClick={() => copy(it.label, it.value)}
               >
-                {copiedKey === it.label ? '✓ SKOPIOWANO' : 'KOPIUJ'}
+                {copiedKey === it.label
+                  ? kontaktContent.channels.copied
+                  : kontaktContent.channels.copy}
               </button>
             </div>
           </div>
@@ -77,8 +80,12 @@ export function ContactChannels() {
 
       <div className={styles.location}>
         <LocationIcon />
-        <div className={styles.locationCode}>{'// LOKALIZACJA'}</div>
-        <div className={styles.locationCity}>Kraków, Polska</div>
+        <div className={styles.locationCode}>
+          {kontaktContent.channels.location.code}
+        </div>
+        <div className={styles.locationCity}>
+          {kontaktContent.channels.location.city}
+        </div>
         <SiteLocation className={styles.locationCoords} />
       </div>
     </>

--- a/components/sections/contact-channels.tsx
+++ b/components/sections/contact-channels.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { siteEmail, sitePhone, siteCoords } from '@/lib/config';
+import { siteEmail, sitePhone } from '@/lib/config';
+import { SiteLocation } from '@/components/cosmos/site-location';
 import styles from './contact-channels.module.css';
 
 function LocationIcon() {
@@ -78,9 +79,7 @@ export function ContactChannels() {
         <LocationIcon />
         <div className={styles.locationCode}>{'// LOKALIZACJA'}</div>
         <div className={styles.locationCity}>Kraków, Polska</div>
-        <div className={styles.locationCoords}>
-          {siteCoords.lat} · {siteCoords.lng}
-        </div>
+        <SiteLocation className={styles.locationCoords} />
       </div>
     </>
   );

--- a/components/sections/contact-channels.tsx
+++ b/components/sections/contact-channels.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { siteEmail, sitePhone } from '@/lib/config';
+import { siteEmail, sitePhone, siteCoords } from '@/lib/config';
 import styles from './contact-channels.module.css';
 
 function LocationIcon() {
@@ -78,7 +78,9 @@ export function ContactChannels() {
         <LocationIcon />
         <div className={styles.locationCode}>{'// LOKALIZACJA'}</div>
         <div className={styles.locationCity}>Kraków, Polska</div>
-        <div className={styles.locationCoords}>50.0647° N · 19.9450° E</div>
+        <div className={styles.locationCoords}>
+          {siteCoords.lat} · {siteCoords.lng}
+        </div>
       </div>
     </>
   );

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import Link from 'next/link';
 import { siteVersion } from '@/lib/config';
 import { useInView } from '@/hooks/use-in-view';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './hero-section.module.css';
 
 export function HeroSection() {
@@ -32,12 +32,12 @@ export function HeroSection() {
         produkt.
       </p>
       <div className={styles.cta}>
-        <Link href='/oferta' className='btn-cosmic primary'>
-          Zobacz ofertę <span className='arrow'>→</span>
-        </Link>
-        <Link href='/kontakt' className='btn-cosmic'>
-          Skontaktuj się <span className='arrow'>↗</span>
-        </Link>
+        <CosmicButton href='/oferta' variant='primary'>
+          Zobacz ofertę
+        </CosmicButton>
+        <CosmicButton href='/kontakt' arrow='↗'>
+          Skontaktuj się
+        </CosmicButton>
       </div>
     </section>
   );

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -21,11 +21,15 @@ export function HeroSection() {
         <span>{siteVersion}</span>
       </div>
       <h1>
-        <span className='reveal'>{heroContent.headline.word1}</span>{' '}
-        <span className='reveal accent'>{heroContent.headline.word2}</span>
+        <span className='reveal'>{heroContent.headline.line1.plain}</span>{' '}
+        <span className='reveal accent'>
+          {heroContent.headline.line1.accent}
+        </span>
         <br />
-        <span className='reveal'>{heroContent.headline.word3}</span>{' '}
-        <span className='reveal accent'>{heroContent.headline.word4}</span>
+        <span className='reveal'>{heroContent.headline.line2.plain}</span>{' '}
+        <span className='reveal accent'>
+          {heroContent.headline.line2.accent}
+        </span>
         <span className='reveal'>.</span>
       </h1>
       <p className={styles.tag}>{heroContent.tagline}</p>

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { siteVersion } from '@/lib/config';
+import { heroContent } from '@/lib/content/hero';
+import { sharedContent } from '@/lib/content/shared';
 import { useInView } from '@/hooks/use-in-view';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './hero-section.module.css';
@@ -14,29 +16,25 @@ export function HeroSection() {
     >
       <div className={styles.meta}>
         <span className={styles.metaDot} />
-        <span>SYSTEM ONLINE — KRK / 50.06°N 19.94°E</span>
+        <span>{heroContent.meta}</span>
         <span className={styles.metaLine} />
         <span>{siteVersion}</span>
       </div>
       <h1>
-        <span className='reveal'>Składam</span>{' '}
-        <span className='reveal accent'>komputery</span>
+        <span className='reveal'>{heroContent.headline.word1}</span>{' '}
+        <span className='reveal accent'>{heroContent.headline.word2}</span>
         <br />
-        <span className='reveal'>i&nbsp;tworzę</span>{' '}
-        <span className='reveal accent'>strony</span>
+        <span className='reveal'>{heroContent.headline.word3}</span>{' '}
+        <span className='reveal accent'>{heroContent.headline.word4}</span>
         <span className='reveal'>.</span>
       </h1>
-      <p className={styles.tag}>
-        Z Krakowa, dla Ciebie. Dobieram komponenty, składam zestawy, konfiguruję
-        systemy i piszę nowoczesne strony — od pierwszego pomysłu po działający
-        produkt.
-      </p>
+      <p className={styles.tag}>{heroContent.tagline}</p>
       <div className={styles.cta}>
         <CosmicButton href='/oferta' variant='primary'>
-          Zobacz ofertę
+          {sharedContent.cta.seeOffer}
         </CosmicButton>
         <CosmicButton href='/kontakt' arrow='↗'>
-          Skontaktuj się
+          {sharedContent.cta.contact}
         </CosmicButton>
       </div>
     </section>

--- a/components/sections/inquiry-form/form-field.tsx
+++ b/components/sections/inquiry-form/form-field.tsx
@@ -1,0 +1,18 @@
+import styles from './inquiry-form.module.css';
+
+type FormFieldProps = {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+};
+
+export function FormField({ label, htmlFor, children }: FormFieldProps) {
+  return (
+    <div className={styles.field}>
+      <label htmlFor={htmlFor} className={styles.label}>
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/components/sections/inquiry-form/inquiry-form.tsx
+++ b/components/sections/inquiry-form/inquiry-form.tsx
@@ -140,6 +140,7 @@ export function InquiryForm({ defaultService = '' }: Props) {
           type='submit'
           variant='primary'
           disabled={isPending || !selectedService}
+          arrow={isPending ? false : '→'}
         >
           {isPending ? 'Wysyłanie…' : 'Wyślij wiadomość'}
         </CosmicButton>

--- a/components/sections/inquiry-form/inquiry-form.tsx
+++ b/components/sections/inquiry-form/inquiry-form.tsx
@@ -6,6 +6,7 @@ import { ScrollReveal } from '@/components/cosmos/scroll-reveal';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import { services } from '@/lib/services/data';
 import { siteEmail } from '@/lib/config';
+import { kontaktContent } from '@/lib/content/kontakt';
 import { FormField } from './form-field';
 import { ServiceDropdown } from './service-dropdown';
 import { SuccessCard } from './success-card';
@@ -22,7 +23,7 @@ type FormState =
 
 const serviceOptions = [
   ...services.map((s) => ({ value: s.slug, label: s.title })),
-  { value: 'inne', label: 'Inne' },
+  { value: 'inne', label: kontaktContent.form.dropdown.other },
 ];
 
 export function InquiryForm({ defaultService = '' }: Props) {
@@ -57,13 +58,16 @@ export function InquiryForm({ defaultService = '' }: Props) {
         />
         <input type='hidden' name='service' value={selectedService} />
 
-        <FormField label='Imię i nazwisko' htmlFor='inq-name'>
+        <FormField
+          label={kontaktContent.form.fields.name.label}
+          htmlFor='inq-name'
+        >
           <input
             id='inq-name'
             name='name'
             type='text'
             className={styles.input}
-            placeholder='Jan Kowalski'
+            placeholder={kontaktContent.form.fields.name.placeholder}
             data-interactive
             required
             minLength={2}
@@ -72,20 +76,23 @@ export function InquiryForm({ defaultService = '' }: Props) {
           />
         </FormField>
 
-        <FormField label='Adres e-mail' htmlFor='inq-email'>
+        <FormField
+          label={kontaktContent.form.fields.email.label}
+          htmlFor='inq-email'
+        >
           <input
             id='inq-email'
             name='email'
             type='email'
             className={styles.input}
-            placeholder='jan@example.com'
+            placeholder={kontaktContent.form.fields.email.placeholder}
             data-interactive
             required
             autoComplete='email'
           />
         </FormField>
 
-        <FormField label='Usługa'>
+        <FormField label={kontaktContent.form.fields.service.label}>
           <ServiceDropdown
             options={serviceOptions}
             value={selectedService}
@@ -94,13 +101,16 @@ export function InquiryForm({ defaultService = '' }: Props) {
         </FormField>
 
         {selectedService === 'inne' && (
-          <FormField label='Temat' htmlFor='inq-topic'>
+          <FormField
+            label={kontaktContent.form.fields.topic.label}
+            htmlFor='inq-topic'
+          >
             <input
               id='inq-topic'
               name='topic'
               type='text'
               className={styles.input}
-              placeholder='Opisz czego dotyczy zapytanie…'
+              placeholder={kontaktContent.form.fields.topic.placeholder}
               data-interactive
               required
               minLength={2}
@@ -109,12 +119,15 @@ export function InquiryForm({ defaultService = '' }: Props) {
           </FormField>
         )}
 
-        <FormField label='Wiadomość' htmlFor='inq-message'>
+        <FormField
+          label={kontaktContent.form.fields.message.label}
+          htmlFor='inq-message'
+        >
           <textarea
             id='inq-message'
             name='message'
             className={styles.textarea}
-            placeholder='Opisz swój projekt lub pytanie…'
+            placeholder={kontaktContent.form.fields.message.placeholder}
             data-interactive
             required
             minLength={10}
@@ -142,7 +155,9 @@ export function InquiryForm({ defaultService = '' }: Props) {
           disabled={isPending || !selectedService}
           arrow={isPending ? false : '→'}
         >
-          {isPending ? 'Wysyłanie…' : 'Wyślij wiadomość'}
+          {isPending
+            ? kontaktContent.form.submit.pending
+            : kontaktContent.form.submit.idle}
         </CosmicButton>
       </form>
     </ScrollReveal>

--- a/components/sections/inquiry-form/inquiry-form.tsx
+++ b/components/sections/inquiry-form/inquiry-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useState } from 'react';
 import { submitInquiry } from '@/app/kontakt/actions';
 import { ScrollReveal } from '@/components/cosmos/scroll-reveal';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import { services } from '@/lib/services/data';
 import { siteEmail } from '@/lib/config';
 import { ServiceDropdown } from './service-dropdown';
@@ -147,14 +148,13 @@ export function InquiryForm({ defaultService = '' }: Props) {
           </p>
         )}
 
-        <button
+        <CosmicButton
           type='submit'
-          className='btn-cosmic primary'
+          variant='primary'
           disabled={isPending || !selectedService}
-          aria-disabled={isPending || !selectedService}
         >
-          {isPending ? 'Wysyłanie…' : 'Wyślij wiadomość →'}
-        </button>
+          {isPending ? 'Wysyłanie…' : 'Wyślij wiadomość'}
+        </CosmicButton>
       </form>
     </ScrollReveal>
   );

--- a/components/sections/inquiry-form/inquiry-form.tsx
+++ b/components/sections/inquiry-form/inquiry-form.tsx
@@ -6,6 +6,7 @@ import { ScrollReveal } from '@/components/cosmos/scroll-reveal';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import { services } from '@/lib/services/data';
 import { siteEmail } from '@/lib/config';
+import { FormField } from './form-field';
 import { ServiceDropdown } from './service-dropdown';
 import { SuccessCard } from './success-card';
 import styles from './inquiry-form.module.css';
@@ -56,10 +57,7 @@ export function InquiryForm({ defaultService = '' }: Props) {
         />
         <input type='hidden' name='service' value={selectedService} />
 
-        <div className={styles.field}>
-          <label htmlFor='inq-name' className={styles.label}>
-            Imię i nazwisko
-          </label>
+        <FormField label='Imię i nazwisko' htmlFor='inq-name'>
           <input
             id='inq-name'
             name='name'
@@ -72,12 +70,9 @@ export function InquiryForm({ defaultService = '' }: Props) {
             maxLength={80}
             autoComplete='name'
           />
-        </div>
+        </FormField>
 
-        <div className={styles.field}>
-          <label htmlFor='inq-email' className={styles.label}>
-            Adres e-mail
-          </label>
+        <FormField label='Adres e-mail' htmlFor='inq-email'>
           <input
             id='inq-email'
             name='email'
@@ -88,22 +83,18 @@ export function InquiryForm({ defaultService = '' }: Props) {
             required
             autoComplete='email'
           />
-        </div>
+        </FormField>
 
-        <div className={styles.field}>
-          <label className={styles.label}>Usługa</label>
+        <FormField label='Usługa'>
           <ServiceDropdown
             options={serviceOptions}
             value={selectedService}
             onChange={setSelectedService}
           />
-        </div>
+        </FormField>
 
         {selectedService === 'inne' && (
-          <div className={styles.field}>
-            <label htmlFor='inq-topic' className={styles.label}>
-              Temat
-            </label>
+          <FormField label='Temat' htmlFor='inq-topic'>
             <input
               id='inq-topic'
               name='topic'
@@ -115,13 +106,10 @@ export function InquiryForm({ defaultService = '' }: Props) {
               minLength={2}
               maxLength={200}
             />
-          </div>
+          </FormField>
         )}
 
-        <div className={styles.field}>
-          <label htmlFor='inq-message' className={styles.label}>
-            Wiadomość
-          </label>
+        <FormField label='Wiadomość' htmlFor='inq-message'>
           <textarea
             id='inq-message'
             name='message'
@@ -132,7 +120,7 @@ export function InquiryForm({ defaultService = '' }: Props) {
             minLength={10}
             maxLength={2000}
           />
-        </div>
+        </FormField>
 
         {state?.ok === false && (
           <p className={styles.error} role='alert'>

--- a/components/sections/inquiry-form/service-dropdown.tsx
+++ b/components/sections/inquiry-form/service-dropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { kontaktContent } from '@/lib/content/kontakt';
 import styles from './inquiry-form.module.css';
 
 type Option = { value: string; label: string };
@@ -36,7 +37,7 @@ export function ServiceDropdown({ options, value, onChange }: Props) {
         aria-haspopup='listbox'
         aria-expanded={isOpen}
       >
-        {selected ? selected.label : '— wybierz usługę —'}
+        {selected ? selected.label : kontaktContent.form.dropdown.placeholder}
         <span
           className={`${styles.selectArrow}${isOpen ? ` ${styles.selectArrowOpen}` : ''}`}
         >

--- a/components/sections/inquiry-form/success-card.tsx
+++ b/components/sections/inquiry-form/success-card.tsx
@@ -1,12 +1,17 @@
+import { kontaktContent } from '@/lib/content/kontakt';
 import styles from './inquiry-form.module.css';
 
 export function SuccessCard() {
   return (
     <div className={styles.success}>
-      <div className={styles.successCode}>{'// MSG_SENT ✓'}</div>
-      <div className={styles.successTitle}>Wiadomość wysłana</div>
+      <div className={styles.successCode}>
+        {kontaktContent.successCard.code}
+      </div>
+      <div className={styles.successTitle}>
+        {kontaktContent.successCard.title}
+      </div>
       <div className={styles.successBody}>
-        Odezwę się tak szybko, jak to możliwe — zazwyczaj w ciągu 24 godzin.
+        {kontaktContent.successCard.body}
       </div>
     </div>
   );

--- a/components/sections/service-cards.tsx
+++ b/components/sections/service-cards.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { Service } from '@/lib/services/types';
+import { ofertaContent } from '@/lib/content/oferta';
 import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './service-cards.module.css';
 
@@ -63,7 +64,9 @@ export function ServiceCards({
             ))}
           </ul>
           <CosmicButton href={`/oferta/${s.slug}`} className={styles.cardCta}>
-            {detail ? 'Szczegóły usługi' : 'Czytaj więcej'}
+            {detail
+              ? ofertaContent.cards.ctaDetail
+              : ofertaContent.cards.ctaPreview}
           </CosmicButton>
         </div>
       ))}

--- a/components/sections/service-cards.tsx
+++ b/components/sections/service-cards.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
 import type { Service } from '@/lib/services/types';
+import { CosmicButton } from '@/components/cosmos/cosmic-button';
 import styles from './service-cards.module.css';
 
 type ServiceCardsProps = {
@@ -62,13 +62,9 @@ export function ServiceCards({
               <li key={f}>{f}</li>
             ))}
           </ul>
-          <Link
-            href={`/oferta/${s.slug}`}
-            className={`btn-cosmic ${styles.cardCta}`}
-          >
-            {detail ? 'Szczegóły usługi' : 'Czytaj więcej'}{' '}
-            <span className='arrow'>→</span>
-          </Link>
+          <CosmicButton href={`/oferta/${s.slug}`} className={styles.cardCta}>
+            {detail ? 'Szczegóły usługi' : 'Czytaj więcej'}
+          </CosmicButton>
         </div>
       ))}
     </div>

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,3 +4,8 @@ export const siteEmail = 'kris1027.dev@gmail.com';
 export const sitePhone = '+48 792 542 841';
 export const githubUrl = 'https://github.com/Kris1027';
 export const linkedinUrl = 'https://linkedin.com/in/krzysztof-obarzanek';
+export const siteCoords = {
+  lat: '50.0647° N',
+  lng: '19.9450° E',
+  city: 'Kraków',
+};

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,8 +4,3 @@ export const siteEmail = 'kris1027.dev@gmail.com';
 export const sitePhone = '+48 792 542 841';
 export const githubUrl = 'https://github.com/Kris1027';
 export const linkedinUrl = 'https://linkedin.com/in/krzysztof-obarzanek';
-export const siteCoords = {
-  lat: '50.0647° N',
-  lng: '19.9450° E',
-  city: 'Kraków',
-};

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -4,3 +4,4 @@ export const siteEmail = 'kris1027.dev@gmail.com';
 export const sitePhone = '+48 792 542 841';
 export const githubUrl = 'https://github.com/Kris1027';
 export const linkedinUrl = 'https://linkedin.com/in/krzysztof-obarzanek';
+export const siteCoords = '50.0647° N · 19.9450° E';

--- a/lib/content/about.ts
+++ b/lib/content/about.ts
@@ -9,10 +9,7 @@ export const aboutContent = {
     role: '// inżynier · krk',
     name: 'Krzysztof Obarzanek',
     bio: 'Jestem pasjonatem technologii, który kocha doradzać w doborze sprzętu, składać komputery i tworzyć strony internetowe. Moja pasja do technologii napędza mnie do nieustannego doskonalenia swoich umiejętności i tworzenia rozwiązań, które łączą innowację z praktycznością.',
-    btns: {
-      oferta: 'Zobacz ofertę',
-      kontakt: 'Kontakt',
-    },
+    btnKontakt: 'Kontakt',
   },
   tech: {
     code: '// tech',

--- a/lib/content/about.ts
+++ b/lib/content/about.ts
@@ -1,0 +1,60 @@
+export const aboutContent = {
+  section: {
+    code: '// 02',
+    title: 'O mnie',
+    kicker: '// transmisja osobista',
+  },
+  profile: {
+    imageAlt: 'Krzysztof',
+    role: '// inżynier · krk',
+    name: 'Krzysztof Obarzanek',
+    bio: 'Jestem pasjonatem technologii, który kocha doradzać w doborze sprzętu, składać komputery i tworzyć strony internetowe. Moja pasja do technologii napędza mnie do nieustannego doskonalenia swoich umiejętności i tworzenia rozwiązań, które łączą innowację z praktycznością.',
+    btns: {
+      oferta: 'Zobacz ofertę',
+      kontakt: 'Kontakt',
+    },
+  },
+  tech: {
+    code: '// tech',
+    title: 'Technologie',
+    kicker: 'Narzędzia, z których korzystam w pracy',
+  },
+  technologies: [
+    [
+      'Frontend',
+      [
+        'HTML5',
+        'CSS3',
+        'JavaScript',
+        'TypeScript',
+        'Next.js',
+        'Astro',
+        'TailwindCSS',
+        'shadcn/ui',
+        'SCSS',
+        'TanStack',
+      ],
+    ],
+    ['Mobile', ['React Native', 'Expo', 'Telegram Mini Apps']],
+    ['Backend', ['Node.js', 'NestJS', 'Express', 'Swagger', 'JWT']],
+    ['Bazy', ['PostgreSQL', 'MongoDB', 'Prisma', 'Supabase', 'Firebase']],
+    ['Web3', ['Ethers.js', 'Web3']],
+    [
+      'Testy',
+      ['Jest', 'Cypress', 'Supertest', 'React Testing Library', 'Playwright'],
+    ],
+    ['DevOps', ['Git', 'Docker', 'Grafana', 'Prometheus']],
+    [
+      'Edytory',
+      [
+        'Codex',
+        'Claude Code',
+        'Cursor',
+        'GitHub Copilot',
+        'VS Code',
+        'Neovim',
+        'WebStorm',
+      ],
+    ],
+  ] as [string, string[]][],
+} as const;

--- a/lib/content/hero.ts
+++ b/lib/content/hero.ts
@@ -1,10 +1,8 @@
 export const heroContent = {
   meta: 'SYSTEM ONLINE — KRK / 50.06°N 19.94°E',
   headline: {
-    word1: 'Składam',
-    word2: 'komputery',
-    word3: 'i tworzę',
-    word4: 'strony',
+    line1: { plain: 'Składam', accent: 'komputery' },
+    line2: { plain: 'i tworzę', accent: 'strony' },
   },
   tagline:
     'Z Krakowa, dla Ciebie. Dobieram komponenty, składam zestawy, konfiguruję systemy i piszę nowoczesne strony — od pierwszego pomysłu po działający produkt.',

--- a/lib/content/hero.ts
+++ b/lib/content/hero.ts
@@ -1,0 +1,11 @@
+export const heroContent = {
+  meta: 'SYSTEM ONLINE — KRK / 50.06°N 19.94°E',
+  headline: {
+    word1: 'Składam',
+    word2: 'komputery',
+    word3: 'i tworzę',
+    word4: 'strony',
+  },
+  tagline:
+    'Z Krakowa, dla Ciebie. Dobieram komponenty, składam zestawy, konfiguruję systemy i piszę nowoczesne strony — od pierwszego pomysłu po działający produkt.',
+} as const;

--- a/lib/content/home.ts
+++ b/lib/content/home.ts
@@ -11,8 +11,7 @@ export const homeContent = {
   },
   callout: {
     imageAlt: 'PC z RGB',
-    heading: 'Nie kupuj gotowców',
-    headingEmphasis: 'PC',
+    heading: { before: 'Nie kupuj gotowców', em: 'PC' },
     body1:
       'Gotowe zestawy komputerowe to często strata pieniędzy. Sklepy montują w nich źle dobrane komponenty, a bardzo często wykorzystują części, które zalegają na magazynie. Efekt? Słabsza wydajność i brak sensownej rozbudowy.',
     body2:

--- a/lib/content/home.ts
+++ b/lib/content/home.ts
@@ -1,0 +1,22 @@
+export const homeContent = {
+  carousel: {
+    code: '// 01',
+    title: 'Co buduję',
+    kicker: 'Wybrane usługi w transmisji na żywo',
+  },
+  oferta: {
+    code: '// 02',
+    title: 'Pełna oferta',
+    kicker: 'Cztery moduły, jeden inżynier',
+  },
+  callout: {
+    imageAlt: 'PC z RGB',
+    heading: 'Nie kupuj gotowców',
+    headingEmphasis: 'PC',
+    body1:
+      'Gotowe zestawy komputerowe to często strata pieniędzy. Sklepy montują w nich źle dobrane komponenty, a bardzo często wykorzystują części, które zalegają na magazynie. Efekt? Słabsza wydajność i brak sensownej rozbudowy.',
+    body2:
+      'Za cenę gotowca złożę komputer znacznie wydajniejszy, idealnie dopasowany do Twoich potrzeb i budżetu. Napisz — doradzę i złożę lepszy zestaw.',
+    cta: 'Napisz do mnie',
+  },
+} as const;

--- a/lib/content/kontakt.ts
+++ b/lib/content/kontakt.ts
@@ -1,0 +1,49 @@
+export const kontaktContent = {
+  page: {
+    inquiry: {
+      code: '// MSG',
+      title: 'Wyślij zapytanie',
+      kicker: 'Opisz swój projekt — odpowiem w ciągu 24 godzin',
+    },
+    contact: {
+      code: '// 04',
+      title: 'Kontakt',
+      kicker: 'Otwórz kanał komunikacji — odpowiem szybko',
+    },
+  },
+  form: {
+    fields: {
+      name: { label: 'Imię i nazwisko', placeholder: 'Jan Kowalski' },
+      email: { label: 'Adres e-mail', placeholder: 'jan@example.com' },
+      service: { label: 'Usługa' },
+      topic: { label: 'Temat', placeholder: 'Opisz czego dotyczy zapytanie…' },
+      message: {
+        label: 'Wiadomość',
+        placeholder: 'Opisz swój projekt lub pytanie…',
+      },
+    },
+    submit: {
+      idle: 'Wyślij wiadomość',
+      pending: 'Wysyłanie…',
+    },
+    dropdown: {
+      placeholder: '— wybierz usługę —',
+      other: 'Inne',
+    },
+  },
+  successCard: {
+    code: '// MSG_SENT ✓',
+    title: 'Wiadomość wysłana',
+    body: 'Odezwę się tak szybko, jak to możliwe — zazwyczaj w ciągu 24 godzin.',
+  },
+  channels: {
+    email: { label: 'Email', actionLabel: 'NAPISZ' },
+    phone: { label: 'Telefon / WhatsApp', actionLabel: 'ZADZWOŃ' },
+    copy: 'KOPIUJ',
+    copied: '✓ SKOPIOWANO',
+    location: {
+      code: '// LOKALIZACJA',
+      city: 'Kraków, Polska',
+    },
+  },
+} as const;

--- a/lib/content/layout.ts
+++ b/lib/content/layout.ts
@@ -1,0 +1,15 @@
+export const layoutContent = {
+  header: {
+    brandName: 'zaruszaj',
+    brandAccent: '.pl',
+    brandSub: '// pc.builds × code.deploy ── KRK',
+  },
+  footer: {
+    nav: '// nawigacja',
+    oferta: '// oferta',
+    kontakt: '// kontakt',
+    status: 'SYS_LINK STABLE',
+    location: '// Kraków',
+    copyright: 'zaruszaj.pl',
+  },
+} as const;

--- a/lib/content/oferta.ts
+++ b/lib/content/oferta.ts
@@ -1,0 +1,46 @@
+export const ofertaContent = {
+  page: {
+    code: '// 03',
+    title: 'Oferta',
+    kicker: 'Cztery moduły gotowe do uruchomienia',
+  },
+  detail: {
+    breadcrumb: 'Oferta',
+    meta: {
+      timeKey: '// czas realizacji',
+      pricingKey: '// rozliczenie',
+    },
+    btns: {
+      inquire: 'Zapytaj o tę usługę',
+      allServices: 'Wszystkie usługi',
+    },
+    sections: {
+      opis: {
+        code: '// opis',
+        title: 'Co dostajesz',
+        kicker: 'Pełny zakres tej usługi',
+      },
+      proces: {
+        code: '// proces',
+        title: 'Jak pracuję',
+        kicker: 'Krok po kroku, bez niespodzianek',
+      },
+      efekt: {
+        code: '// efekt',
+        title: 'Co dostajesz na koniec',
+        kicker: 'Konkretne deliverables',
+      },
+    },
+    cta: {
+      kicker: '// gotowy?',
+      heading: 'Otwórz kanał komunikacji.',
+      body: 'Napisz krótko czego potrzebujesz — odpiszę najczęściej tego samego dnia z konkretną wyceną i terminem.',
+      primary: 'Skontaktuj się',
+      next: 'Następna:',
+    },
+  },
+  cards: {
+    ctaPreview: 'Czytaj więcej',
+    ctaDetail: 'Szczegóły usługi',
+  },
+} as const;

--- a/lib/content/shared.ts
+++ b/lib/content/shared.ts
@@ -1,0 +1,6 @@
+export const sharedContent = {
+  cta: {
+    seeOffer: 'Zobacz ofertę',
+    contact: 'Skontaktuj się',
+  },
+} as const;


### PR DESCRIPTION
## Summary

- Extract reusable `FormField` component to remove repeated label+input wrapper in the inquiry form
- Centralize all user-visible text into `lib/content/` constants — 7 files covering hero, home, about, oferta, kontakt, layout, and shared CTAs
- Replace `siteCoords` config object with a single `SiteLocation` component
- Move inquiry form above contact channels on the kontakt page

## Details

All hardcoded strings across pages and components now live in `lib/content/`:
- `shared.ts` — repeated CTAs ("Zobacz ofertę", "Skontaktuj się")
- `hero.ts` — meta bar, headline words, tagline
- `home.ts` — section labels, callout copy
- `about.ts` — bio, role, technologies list, section labels
- `oferta.ts` — page/detail section labels, meta keys, button labels, CTA section
- `kontakt.ts` — form field labels/placeholders, submit button, success card, contact channel labels
- `layout.ts` — header brand text, footer section headings, status indicator

To change any user-visible text, edit the relevant constant in `lib/content/` — no component changes needed.

## Test plan

- [ ] All pages render correctly with no visual regressions
- [ ] Contact form submits successfully and shows success card
- [ ] Service detail pages display correct static labels
- [ ] Header brand text and footer headings display correctly
- [ ] TypeScript and build pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)