### PR TITLE
feat: boot-sequence mobile nav overlay

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -20,6 +20,9 @@
   --theme-hue: 160;
   --theme-hue-2: 140;
   --theme-acc-hue: 165;
+  /* 14px pad + 52px BrandMark + 14px pad + 1px border. The mobile-nav overlay
+     anchors below this so the sticky header stays visible above it. */
+  --header-height: 81px;
 }
 
 [data-theme='emerald'] {

--- a/components/layout/header.module.css
+++ b/components/layout/header.module.css
@@ -62,22 +62,6 @@
   gap: 4px;
 }
 
-.navToggle {
-  display: none;
-  padding: 10px;
-  flex-direction: column;
-  gap: 4px;
-  background: none;
-  border: none;
-}
-
-.navToggle span {
-  width: 22px;
-  height: 1px;
-  background: var(--ink-1);
-  display: block;
-}
-
 .navLink {
   position: relative;
   padding: 10px 14px;
@@ -131,22 +115,5 @@
 @media (max-width: 800px) {
   .nav {
     display: none;
-  }
-
-  .navToggle {
-    display: flex;
-  }
-
-  .navMobile {
-    display: flex;
-    flex-direction: column;
-    border-top: 1px solid var(--line);
-    padding: 12px 28px 18px;
-    background: oklch(0.05 0.04 var(--theme-hue) / 0.85);
-  }
-
-  .navMobile .navLink {
-    width: 100%;
-    padding: 12px 8px;
   }
 }

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -2,10 +2,10 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useState } from 'react';
 import { BrandMark } from '@/components/cosmos/brand-mark';
 import { navLinks } from '@/lib/nav';
 import { layoutContent } from '@/lib/content/layout';
+import { MobileNav } from './mobile-nav/mobile-nav';
 import styles from './header.module.css';
 
 function isActive(pathname: string, href: string): boolean {
@@ -18,34 +18,23 @@ type NavLinkProps = {
   code: string;
   label: string;
   active: boolean;
-  showDot?: boolean;
-  onClick?: () => void;
 };
 
-function NavLink({
-  href,
-  code,
-  label,
-  active,
-  showDot,
-  onClick,
-}: NavLinkProps) {
+function NavLink({ href, code, label, active }: NavLinkProps) {
   return (
     <Link
       href={href}
       className={`${styles.navLink}${active ? ` ${styles.navLinkActive}` : ''}`}
-      onClick={onClick}
     >
       <span className={styles.navCode}>{code}</span>
       <span>{label}</span>
-      {active && showDot && <span className={styles.navDot} />}
+      {active && <span className={styles.navDot} />}
     </Link>
   );
 }
 
 export function Header() {
   const pathname = usePathname();
-  const [open, setOpen] = useState(false);
 
   return (
     <header className={styles.header}>
@@ -67,38 +56,12 @@ export function Header() {
 
         <nav className={styles.nav}>
           {navLinks.map((l) => (
-            <NavLink
-              key={l.href}
-              {...l}
-              active={isActive(pathname, l.href)}
-              showDot
-            />
+            <NavLink key={l.href} {...l} active={isActive(pathname, l.href)} />
           ))}
         </nav>
 
-        <button
-          className={styles.navToggle}
-          onClick={() => setOpen((o) => !o)}
-          aria-label='menu'
-        >
-          <span />
-          <span />
-          <span />
-        </button>
+        <MobileNav />
       </div>
-
-      {open && (
-        <div className={styles.navMobile}>
-          {navLinks.map((l) => (
-            <NavLink
-              key={l.href}
-              {...l}
-              active={isActive(pathname, l.href)}
-              onClick={() => setOpen(false)}
-            />
-          ))}
-        </div>
-      )}
     </header>
   );
 }

--- a/components/layout/mobile-nav/boot-data.ts
+++ b/components/layout/mobile-nav/boot-data.ts
@@ -1,0 +1,29 @@
+export type BootLogTone = 'accent' | 'dim' | 'highlight';
+
+export type BootLogLine = {
+  t: string;
+  m: string;
+  tone: BootLogTone;
+};
+
+export const BOOT_LOG: readonly BootLogLine[] = [
+  { t: '0.000', m: 'init.zaruszaj — kernel v1.01', tone: 'accent' },
+  { t: '0.012', m: 'mounting /pages ........... ok', tone: 'dim' },
+  { t: '0.024', m: 'starting compositor ....... ok', tone: 'dim' },
+  { t: '0.041', m: 'fetching routes [4/4] ..... ok', tone: 'dim' },
+  { t: '0.063', m: 'menu.exec --list', tone: 'highlight' },
+] as const;
+
+export const TYPING_PHRASES: readonly string[] = [
+  'cd ./offer',
+  'cat ./about.md',
+  'curl /contact',
+  'open /home',
+] as const;
+
+export const NAV_DESC: Record<string, string> = {
+  '/': 'index.tsx',
+  '/o-mnie': 'whoami',
+  '/oferta': 'ls ./services',
+  '/kontakt': 'mail to:',
+};

--- a/components/layout/mobile-nav/boot-log.module.css
+++ b/components/layout/mobile-nav/boot-log.module.css
@@ -1,0 +1,53 @@
+.log {
+  padding: 14px 18px 10px;
+  font-size: 10.5px;
+  line-height: 1.6;
+  border-bottom: 1px dashed var(--line);
+}
+
+.line {
+  display: flex;
+  gap: 10px;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition:
+    opacity 180ms ease-out,
+    transform 180ms ease-out;
+  /* Resting / closing: reverse stagger (last line leaves first) */
+  transition-delay: calc((var(--total) - 1 - var(--idx)) * 25ms);
+}
+
+:global(.is-open) .line {
+  opacity: 1;
+  transform: translateY(0);
+  /* Forward stagger on open */
+  transition-delay: calc(var(--idx) * 75ms);
+}
+
+.timestamp {
+  color: var(--ink-4);
+  width: 38px;
+  flex-shrink: 0;
+}
+
+.message {
+  color: var(--ink-3);
+}
+
+.accent .message {
+  color: var(--acc);
+}
+
+.highlight .message {
+  color: var(--ink-0);
+}
+
+.dim .message {
+  color: var(--ink-3);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .line {
+    transition: none;
+  }
+}

--- a/components/layout/mobile-nav/boot-log.tsx
+++ b/components/layout/mobile-nav/boot-log.tsx
@@ -1,0 +1,27 @@
+import type { CSSProperties } from 'react';
+import { BOOT_LOG } from './boot-data';
+import styles from './boot-log.module.css';
+
+export function BootLog() {
+  const total = BOOT_LOG.length;
+
+  return (
+    <div className={styles.log} aria-hidden='true'>
+      {BOOT_LOG.map((line, i) => (
+        <div
+          key={i}
+          className={`${styles.line} ${styles[line.tone]}`}
+          style={
+            {
+              '--idx': i,
+              '--total': total,
+            } as CSSProperties
+          }
+        >
+          <span className={styles.timestamp}>[{line.t}]</span>
+          <span className={styles.message}>{line.m}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/layout/mobile-nav/footer-block.module.css
+++ b/components/layout/mobile-nav/footer-block.module.css
@@ -1,0 +1,105 @@
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 18px 14px;
+  border-top: 1px solid var(--line);
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
+.heading,
+.linkItem {
+  opacity: 0;
+  transform: translateY(10px);
+  transition:
+    opacity 350ms ease-out,
+    transform 350ms ease-out;
+  /* Resting / closing: no extra delay; everything fades together quickly */
+  transition-delay: 0ms;
+}
+
+:global(.is-open) .heading,
+:global(.is-open) .linkItem {
+  opacity: 1;
+  transform: translateY(0);
+  /* Forward stagger after menu has settled (~960ms): bottom link first */
+  transition-delay: calc(960ms + var(--idx) * 80ms);
+}
+
+.heading {
+  color: var(--acc);
+  font-size: 10.5px;
+}
+
+.links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  color: var(--ink-2);
+  text-decoration: none;
+  font-size: 11px;
+  transition: color 150ms ease-out;
+}
+
+.link:hover,
+.link:focus-visible {
+  color: var(--ink-0);
+  outline: none;
+}
+
+.arrow {
+  color: var(--acc);
+  font-size: 12px;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--line);
+  color: var(--ink-3);
+  font-size: 10px;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--acc);
+  box-shadow: 0 0 6px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.4);
+    opacity: 0.6;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heading,
+  .linkItem {
+    transition: none;
+  }
+  .dot {
+    animation: none;
+  }
+}

--- a/components/layout/mobile-nav/footer-block.tsx
+++ b/components/layout/mobile-nav/footer-block.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+import { services } from '@/lib/services/data';
+import { navLinks } from '@/lib/nav';
+import { NAV_DESC } from './boot-data';
+import styles from './footer-block.module.css';
+
+type FooterBlockProps = {
+  pathname: string;
+  onSelect: () => void;
+};
+
+function activeNavHref(pathname: string): string {
+  if (pathname === '/') return '/';
+  const match = navLinks.find(
+    (l) => l.href !== '/' && pathname.startsWith(l.href)
+  );
+  return match?.href ?? '/';
+}
+
+export function FooterBlock({ pathname, onSelect }: FooterBlockProps) {
+  const linkCount = services.length;
+  // We want bottom link to rise first, then up the stack, then `// oferta` last.
+  // Stagger index 0 = last (bottom) link, index linkCount = `// oferta` heading.
+  const total = linkCount + 1;
+  const headingIdx = total - 1;
+  const activeDesc = NAV_DESC[activeNavHref(pathname)] ?? '';
+
+  return (
+    <div className={styles.footer}>
+      <div
+        className={styles.heading}
+        style={
+          {
+            '--idx': headingIdx,
+            '--total': total,
+          } as CSSProperties
+        }
+      >
+        {'// oferta'}
+      </div>
+
+      <ul className={styles.links}>
+        {services.map((service, i) => {
+          // Reverse: last service (bottom) rises first → idx 0
+          const idx = linkCount - 1 - i;
+          return (
+            <li
+              key={service.slug}
+              style={
+                {
+                  '--idx': idx,
+                  '--total': total,
+                } as CSSProperties
+              }
+              className={styles.linkItem}
+            >
+              <Link
+                href={`/oferta/${service.slug}`}
+                onClick={onSelect}
+                className={styles.link}
+              >
+                <span className={styles.arrow} aria-hidden='true'>
+                  ↗
+                </span>
+                <span>{service.title}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className={styles.status} aria-hidden='true'>
+        <span className={styles.dot} />
+        <span>online · {activeDesc}</span>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/mobile-nav/menu-items.module.css
+++ b/components/layout/mobile-nav/menu-items.module.css
@@ -1,0 +1,134 @@
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 12px;
+  flex: 1;
+  overflow: auto;
+}
+
+.item {
+  opacity: 0;
+  transform: translateX(-14px);
+  transition:
+    opacity 250ms ease-out,
+    transform 400ms cubic-bezier(0.2, 0.8, 0.3, 1);
+  /* Resting / closing: reverse stagger so last item leaves first */
+  transition-delay: calc((var(--total) - 1 - var(--idx)) * 55ms);
+}
+
+:global(.is-open) .item {
+  opacity: 1;
+  transform: translateX(0);
+  /* Forward stagger after boot log + breath: ~555ms */
+  transition-delay: calc(555ms + var(--idx) * 95ms);
+}
+
+.link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 12px;
+  margin-bottom: 4px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink-1);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 150ms ease-out,
+    border-color 150ms ease-out,
+    color 150ms ease-out;
+}
+
+.link:hover,
+.link:focus-visible {
+  background: oklch(1 0.04 var(--theme-hue, 160) / 0.04);
+  outline: none;
+}
+
+.link:focus-visible {
+  border-color: oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.4);
+}
+
+.active {
+  background: oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.12);
+  border-color: oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.25);
+  color: var(--ink-0);
+}
+
+.beam {
+  position: absolute;
+  left: -1px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: var(--acc);
+  border-radius: 1px;
+  box-shadow: 0 0 10px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+}
+
+.code {
+  width: 22px;
+  flex-shrink: 0;
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
+.caret {
+  width: 14px;
+  flex-shrink: 0;
+  color: var(--acc);
+  font-size: 14px;
+}
+
+.active .caret {
+  text-shadow: 0 0 8px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+}
+
+.label {
+  flex: 1;
+  font-size: 17px;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+  color: var(--ink-1);
+}
+
+.active .label {
+  color: var(--ink-0);
+}
+
+.desc {
+  color: var(--ink-3);
+  font-size: 10px;
+}
+
+.cursor {
+  width: 8px;
+  height: 16px;
+  margin-left: 4px;
+  background: var(--acc);
+  box-shadow: 0 0 10px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+  animation: blink 1s steps(2) infinite;
+}
+
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item {
+    transition: none;
+  }
+  .cursor {
+    animation: none;
+  }
+}

--- a/components/layout/mobile-nav/menu-items.tsx
+++ b/components/layout/mobile-nav/menu-items.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link';
+import type { CSSProperties, Ref } from 'react';
+import { navLinks } from '@/lib/nav';
+import { NAV_DESC } from './boot-data';
+import styles from './menu-items.module.css';
+
+type MenuItemsProps = {
+  pathname: string;
+  onSelect: () => void;
+  firstLinkRef: Ref<HTMLAnchorElement>;
+};
+
+function isActive(pathname: string, href: string): boolean {
+  if (href === '/') return pathname === '/';
+  return pathname === href || pathname.startsWith(href + '/');
+}
+
+export function MenuItems({
+  pathname,
+  onSelect,
+  firstLinkRef,
+}: MenuItemsProps) {
+  const total = navLinks.length;
+
+  return (
+    <ul className={styles.list}>
+      {navLinks.map((link, i) => {
+        const active = isActive(pathname, link.href);
+        return (
+          <li
+            key={link.href}
+            className={styles.item}
+            style={
+              {
+                '--idx': i,
+                '--total': total,
+              } as CSSProperties
+            }
+          >
+            <Link
+              ref={i === 0 ? firstLinkRef : undefined}
+              href={link.href}
+              onClick={onSelect}
+              className={`${styles.link} ${active ? styles.active : ''}`}
+              aria-current={active ? 'page' : undefined}
+            >
+              {active && <span className={styles.beam} aria-hidden='true' />}
+              <span className={styles.code}>{link.code}</span>
+              <span className={styles.caret} aria-hidden='true'>
+                &gt;
+              </span>
+              <span className={styles.label}>{link.label}</span>
+              <span className={styles.desc} aria-hidden='true'>
+                {NAV_DESC[link.href] ?? ''}
+              </span>
+              {active && <span className={styles.cursor} aria-hidden='true' />}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/components/layout/mobile-nav/mobile-nav.module.css
+++ b/components/layout/mobile-nav/mobile-nav.module.css
@@ -1,0 +1,255 @@
+.root {
+  display: contents;
+}
+
+/* ───── Hamburger / X toggle ───── */
+
+.toggle {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    border-color 200ms ease-out,
+    box-shadow 200ms ease-out;
+}
+
+.toggle:focus-visible {
+  outline: none;
+  border-color: var(--acc);
+  box-shadow: 0 0 0 4px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.18);
+}
+
+.toggle[data-open='true'] {
+  border-color: var(--acc);
+  box-shadow: 0 0 0 4px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.12);
+}
+
+.bar {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  height: 1.5px;
+  background: var(--ink-1);
+  border-radius: 2px;
+  transition:
+    transform 280ms cubic-bezier(0.6, 0.2, 0.2, 1),
+    opacity 150ms ease-out,
+    background 200ms ease-out;
+}
+
+.toggle[data-open='true'] .bar {
+  background: var(--acc);
+}
+
+.bar:nth-child(1) {
+  top: 14px;
+}
+
+.bar:nth-child(2) {
+  top: 21px;
+}
+
+.bar:nth-child(3) {
+  top: 28px;
+}
+
+.toggle[data-open='true'] .bar:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.toggle[data-open='true'] .bar:nth-child(2) {
+  opacity: 0;
+}
+
+.toggle[data-open='true'] .bar:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* ───── Fullscreen overlay ───── */
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: radial-gradient(
+    ellipse at 50% 30%,
+    oklch(0.1 0.04 var(--theme-hue, 160)) 0%,
+    oklch(0.05 0.04 var(--theme-hue, 160)) 70%,
+    var(--void) 100%
+  );
+  font-family: inherit;
+  pointer-events: none;
+  clip-path: inset(100% 0 0 0);
+  transition: clip-path 220ms cubic-bezier(0.5, 0, 0.75, 0);
+  /* Wait for inner items to reverse-stagger out before collapsing */
+  transition-delay: 360ms;
+}
+
+.overlay:global(.is-open) {
+  pointer-events: auto;
+  clip-path: inset(0 0 0 0);
+  transition: clip-path 600ms cubic-bezier(0.7, 0.05, 0.2, 1);
+  transition-delay: 0ms;
+}
+
+/* CRT scanlines */
+.overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    0deg,
+    oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.06) 0,
+    oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.06) 1px,
+    transparent 1px,
+    transparent 4px
+  );
+  mix-blend-mode: screen;
+}
+
+/* CRT vignette */
+.overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+  box-shadow: inset 0 0 80px 20px oklch(0 0 0 / 0.6);
+}
+
+/* ───── Overlay header strip ───── */
+
+.overlayHeader {
+  position: relative;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brandText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  line-height: 1.1;
+}
+
+.brandName {
+  color: var(--ink-0);
+  font-weight: 600;
+  font-size: 18px;
+  letter-spacing: -0.3px;
+}
+
+.brandAccent {
+  color: var(--acc);
+}
+
+.brandSub {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-3);
+  font-size: 10.5px;
+}
+
+.brandDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--acc);
+  box-shadow: 0 0 6px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+}
+
+/* ───── Command line title ───── */
+
+.commandLine {
+  position: relative;
+  z-index: 2;
+  padding: 14px 18px 8px;
+  font-size: 11px;
+  color: var(--ink-2);
+  opacity: 0;
+  transition: opacity 250ms ease-out;
+  transition-delay: 0ms;
+}
+
+:global(.is-open) .commandLine {
+  opacity: 1;
+  /* After boot log finishes (~5 lines × 75ms = 375ms) */
+  transition-delay: 380ms;
+}
+
+.dollar {
+  color: var(--acc);
+}
+
+.flag {
+  color: var(--acc);
+}
+
+.flagDim {
+  color: var(--ink-3);
+}
+
+/* ───── Tail typing prompt container ───── */
+
+.tail {
+  position: relative;
+  z-index: 2;
+  padding: 14px 18px 6px;
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity 300ms ease-out,
+    transform 300ms ease-out;
+  transition-delay: 0ms;
+}
+
+:global(.is-open) .tail {
+  opacity: 1;
+  transform: translateY(0);
+  /* After menu items have settled (~960ms) */
+  transition-delay: 980ms;
+}
+
+/* ───── Hide on desktop ───── */
+
+@media (min-width: 801px) {
+  .root {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay,
+  .commandLine,
+  .tail {
+    transition-duration: 0.01ms;
+    transition-delay: 0ms;
+  }
+  .bar {
+    transition-duration: 0.01ms;
+  }
+}

--- a/components/layout/mobile-nav/mobile-nav.module.css
+++ b/components/layout/mobile-nav/mobile-nav.module.css
@@ -74,9 +74,9 @@
 /* ───── Fullscreen overlay ───── */
 
 .overlay {
-  /* Sits below the sticky app header (~81px = 14px pad + 52px BrandMark + 14px pad + 1px border) */
+  /* Sits below the sticky app header — height defined as --header-height in globals.css. */
   position: fixed;
-  top: 81px;
+  top: var(--header-height);
   right: 0;
   bottom: 0;
   left: 0;

--- a/components/layout/mobile-nav/mobile-nav.module.css
+++ b/components/layout/mobile-nav/mobile-nav.module.css
@@ -74,9 +74,13 @@
 /* ───── Fullscreen overlay ───── */
 
 .overlay {
+  /* Sits below the sticky app header (~81px = 14px pad + 52px BrandMark + 14px pad + 1px border) */
   position: fixed;
-  inset: 0;
-  z-index: 60;
+  top: 81px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 40;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -126,60 +130,6 @@
   z-index: 4;
   pointer-events: none;
   box-shadow: inset 0 0 80px 20px oklch(0 0 0 / 0.6);
-}
-
-/* ───── Overlay header strip ───── */
-
-.overlayHeader {
-  position: relative;
-  z-index: 6;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px 14px;
-  border-bottom: 1px solid var(--line);
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-}
-
-.brandText {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  line-height: 1.1;
-}
-
-.brandName {
-  color: var(--ink-0);
-  font-weight: 600;
-  font-size: 18px;
-  letter-spacing: -0.3px;
-}
-
-.brandAccent {
-  color: var(--acc);
-}
-
-.brandSub {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--ink-3);
-  font-size: 10.5px;
-}
-
-.brandDot {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--acc);
-  box-shadow: 0 0 6px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
 }
 
 /* ───── Command line title ───── */

--- a/components/layout/mobile-nav/mobile-nav.module.css
+++ b/components/layout/mobile-nav/mobile-nav.module.css
@@ -84,18 +84,29 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  background: radial-gradient(
-    ellipse at 50% 30%,
-    oklch(0.1 0.04 var(--theme-hue, 160)) 0%,
-    oklch(0.05 0.04 var(--theme-hue, 160)) 70%,
-    var(--void) 100%
-  );
+  /* Opaque dark base — the inner CosmosBackground canvas paints stars on top of this,
+     and page content behind the overlay is fully hidden. */
+  background: var(--void);
+  /* transform creates a containing block so the inner CosmosBackground's
+     position: fixed canvas anchors to this overlay, not the viewport. */
+  transform: translateZ(0);
   font-family: inherit;
   pointer-events: none;
   clip-path: inset(100% 0 0 0);
   transition: clip-path 220ms cubic-bezier(0.5, 0, 0.75, 0);
   /* Wait for inner items to reverse-stagger out before collapsing */
   transition-delay: 360ms;
+}
+
+/* Wrapper for the inner CosmosBackground — ensures it sits behind all
+   overlay content (z: -1 puts it under non-positioned siblings) and is
+   clipped to the overlay's bounds. */
+.cosmos {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
 }
 
 .overlay:global(.is-open) {

--- a/components/layout/mobile-nav/mobile-nav.test.tsx
+++ b/components/layout/mobile-nav/mobile-nav.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/vitest';
+import { MobileNav } from './mobile-nav';
+
+let mockPathname = '/';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+// CosmosBackground touches canvas APIs jsdom doesn't implement.
+vi.mock('@/components/cosmos/background/background', () => ({
+  CosmosBackground: () => null,
+}));
+
+describe('MobileNav', () => {
+  beforeEach(() => {
+    mockPathname = '/';
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('starts closed with the dialog aria-hidden', () => {
+    render(<MobileNav />);
+    const toggle = screen.getByRole('button', { name: /otwórz menu/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('opens on toggle click and exposes the dialog', async () => {
+    const user = userEvent.setup();
+    render(<MobileNav />);
+    await user.click(screen.getByRole('button', { name: /otwórz menu/i }));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-hidden', 'false');
+    expect(dialog.className).toMatch(/is-open/);
+  });
+
+  it('closes on Escape and returns focus to the toggle', async () => {
+    const user = userEvent.setup();
+    render(<MobileNav />);
+    const toggle = screen.getByRole('button', { name: /otwórz menu/i });
+    await user.click(toggle);
+    await user.keyboard('{Escape}');
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+    expect(toggle).toHaveFocus();
+  });
+
+  it('traps Tab from the last focusable back to the toggle', async () => {
+    const user = userEvent.setup();
+    render(<MobileNav />);
+    const toggle = screen.getByRole('button', { name: /otwórz menu/i });
+    await user.click(toggle);
+
+    const dialog = screen.getByRole('dialog');
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    expect(focusable.length).toBeGreaterThan(0);
+    const last = focusable[focusable.length - 1];
+    last.focus();
+    expect(last).toHaveFocus();
+
+    await user.tab();
+    expect(toggle).toHaveFocus();
+  });
+
+  it('auto-closes when the pathname changes', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<MobileNav />);
+    await user.click(screen.getByRole('button', { name: /otwórz menu/i }));
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-hidden', 'false');
+
+    mockPathname = '/oferta';
+    rerender(<MobileNav />);
+
+    expect(screen.getByRole('dialog', { hidden: true })).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
+});

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -2,8 +2,6 @@
 
 import { usePathname } from 'next/navigation';
 import { useEffect, useId, useRef, useState } from 'react';
-import { BrandMark } from '@/components/cosmos/brand-mark';
-import { layoutContent } from '@/lib/content/layout';
 import { BootLog } from './boot-log';
 import { FooterBlock } from './footer-block';
 import { MenuItems } from './menu-items';
@@ -79,37 +77,6 @@ export function MobileNav() {
         aria-label='Menu'
         className={`${styles.overlay} ${open ? 'is-open' : ''}`}
       >
-        <div className={styles.overlayHeader}>
-          <div className={styles.brand}>
-            <BrandMark size={48} animated={open} />
-            <div className={styles.brandText}>
-              <span className={styles.brandName}>
-                {layoutContent.header.brandName}
-                <span className={styles.brandAccent}>
-                  {layoutContent.header.brandAccent}
-                </span>
-              </span>
-              <span className={styles.brandSub}>
-                <span className={styles.brandDot} aria-hidden='true' />
-                menu — booted in 0.063s
-              </span>
-            </div>
-          </div>
-
-          <button
-            type='button'
-            className={styles.toggle}
-            data-open={true}
-            aria-label='Zamknij menu'
-            onClick={() => setOpen(false)}
-            tabIndex={open ? 0 : -1}
-          >
-            <span className={styles.bar} />
-            <span className={styles.bar} />
-            <span className={styles.bar} />
-          </button>
-        </div>
-
         <BootLog />
 
         <div className={styles.commandLine} aria-hidden='true'>

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -15,8 +15,20 @@ export function MobileNav() {
   const overlayId = useId();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const wasOpenRef = useRef(false);
 
-  // Body scroll lock + Esc key while open
+  // Auto-close on route change so navigations from anywhere (including the
+  // header brand link, which sits outside this component) don't leave the
+  // overlay stuck open. Syncing local UI state to router state is a
+  // legitimate use of setState-in-effect — there's no subscribe API for
+  // Next's pathname.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setOpen(false);
+  }, [pathname]);
+
+  // Body scroll lock + Esc + Tab focus trap while open
   useEffect(() => {
     if (!open) return;
 
@@ -24,7 +36,35 @@ export function MobileNav() {
     document.body.style.overflow = 'hidden';
 
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false);
+      if (e.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      const overlay = overlayRef.current;
+      const button = buttonRef.current;
+      if (!overlay || !button) return;
+
+      const overlayFocusable = Array.from(
+        overlay.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )
+      );
+      // Include the toggle so [Shift+]Tab cycles through it instead of
+      // escaping into the (still mounted) page content behind the overlay.
+      const focusable = [button, ...overlayFocusable];
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
     window.addEventListener('keydown', onKey);
 
@@ -34,24 +74,19 @@ export function MobileNav() {
     };
   }, [open]);
 
-  // Focus management: first link on open, button on close
+  // Focus management: first link on open, toggle on close (ARIA APG pattern).
   useEffect(() => {
     if (open) {
+      wasOpenRef.current = true;
       // Wait for the open transition to start; focusing immediately can cause
       // the browser to scroll the link into view before the overlay paints.
       const id = window.setTimeout(() => firstLinkRef.current?.focus(), 50);
       return () => window.clearTimeout(id);
     }
-    if (document.activeElement instanceof HTMLElement) {
-      // Only return focus if the user was inside the overlay
-      if (
-        buttonRef.current &&
-        document.activeElement !== buttonRef.current &&
-        document.activeElement !== document.body
-      ) {
-        buttonRef.current.focus();
-      }
-    }
+    // Skip the initial render (before the user has ever opened the menu)
+    // so we don't steal focus on page load.
+    if (!wasOpenRef.current) return;
+    buttonRef.current?.focus({ preventScroll: true });
   }, [open]);
 
   return (
@@ -72,10 +107,12 @@ export function MobileNav() {
       </button>
 
       <div
+        ref={overlayRef}
         id={overlayId}
         role='dialog'
         aria-modal='true'
         aria-label='Menu'
+        aria-hidden={!open}
         className={`${styles.overlay} ${open ? 'is-open' : ''}`}
       >
         {open && (

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useId, useRef, useState } from 'react';
+import { BrandMark } from '@/components/cosmos/brand-mark';
+import { layoutContent } from '@/lib/content/layout';
+import { BootLog } from './boot-log';
+import { FooterBlock } from './footer-block';
+import { MenuItems } from './menu-items';
+import { TypingPrompt } from './typing-prompt';
+import styles from './mobile-nav.module.css';
+
+export function MobileNav() {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const overlayId = useId();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const firstLinkRef = useRef<HTMLAnchorElement>(null);
+
+  // Body scroll lock + Esc key while open
+  useEffect(() => {
+    if (!open) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  // Focus management: first link on open, button on close
+  useEffect(() => {
+    if (open) {
+      // Wait for the open transition to start; focusing immediately can cause
+      // the browser to scroll the link into view before the overlay paints.
+      const id = window.setTimeout(() => firstLinkRef.current?.focus(), 50);
+      return () => window.clearTimeout(id);
+    }
+    if (document.activeElement instanceof HTMLElement) {
+      // Only return focus if the user was inside the overlay
+      if (
+        buttonRef.current &&
+        document.activeElement !== buttonRef.current &&
+        document.activeElement !== document.body
+      ) {
+        buttonRef.current.focus();
+      }
+    }
+  }, [open]);
+
+  return (
+    <div className={styles.root}>
+      <button
+        ref={buttonRef}
+        type='button'
+        className={styles.toggle}
+        data-open={open}
+        aria-expanded={open}
+        aria-controls={overlayId}
+        aria-label={open ? 'Zamknij menu' : 'Otwórz menu'}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className={styles.bar} />
+        <span className={styles.bar} />
+        <span className={styles.bar} />
+      </button>
+
+      <div
+        id={overlayId}
+        role='dialog'
+        aria-modal='true'
+        aria-label='Menu'
+        className={`${styles.overlay} ${open ? 'is-open' : ''}`}
+      >
+        <div className={styles.overlayHeader}>
+          <div className={styles.brand}>
+            <BrandMark size={48} animated={open} />
+            <div className={styles.brandText}>
+              <span className={styles.brandName}>
+                {layoutContent.header.brandName}
+                <span className={styles.brandAccent}>
+                  {layoutContent.header.brandAccent}
+                </span>
+              </span>
+              <span className={styles.brandSub}>
+                <span className={styles.brandDot} aria-hidden='true' />
+                menu — booted in 0.063s
+              </span>
+            </div>
+          </div>
+
+          <button
+            type='button'
+            className={styles.toggle}
+            data-open={true}
+            aria-label='Zamknij menu'
+            onClick={() => setOpen(false)}
+            tabIndex={open ? 0 : -1}
+          >
+            <span className={styles.bar} />
+            <span className={styles.bar} />
+            <span className={styles.bar} />
+          </button>
+        </div>
+
+        <BootLog />
+
+        <div className={styles.commandLine} aria-hidden='true'>
+          <span className={styles.dollar}>$</span> nav.exec{' '}
+          <span className={styles.flag}>--list</span>
+          <span className={styles.flagDim}> --verbose</span>
+        </div>
+
+        <MenuItems
+          pathname={pathname}
+          onSelect={() => setOpen(false)}
+          firstLinkRef={firstLinkRef}
+        />
+
+        <div className={styles.tail}>
+          <TypingPrompt active={open} />
+        </div>
+
+        <FooterBlock pathname={pathname} onSelect={() => setOpen(false)} />
+      </div>
+    </div>
+  );
+}

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { useEffect, useId, useRef, useState } from 'react';
+import { CosmosBackground } from '@/components/cosmos/background/background';
 import { BootLog } from './boot-log';
 import { FooterBlock } from './footer-block';
 import { MenuItems } from './menu-items';
@@ -77,6 +78,12 @@ export function MobileNav() {
         aria-label='Menu'
         className={`${styles.overlay} ${open ? 'is-open' : ''}`}
       >
+        {open && (
+          <div className={styles.cosmos} aria-hidden='true'>
+            <CosmosBackground />
+          </div>
+        )}
+
         <BootLog />
 
         <div className={styles.commandLine} aria-hidden='true'>

--- a/components/layout/mobile-nav/typing-prompt.module.css
+++ b/components/layout/mobile-nav/typing-prompt.module.css
@@ -1,0 +1,44 @@
+.prompt {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--ink-1);
+}
+
+.dollar {
+  color: var(--acc);
+}
+
+.text {
+  color: var(--ink-1);
+  white-space: pre;
+}
+
+.cursor {
+  display: inline-block;
+  width: 7px;
+  height: 14px;
+  margin-left: 2px;
+  background: var(--acc);
+  box-shadow: 0 0 8px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+  animation: blink 1s steps(2) infinite;
+}
+
+@keyframes blink {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor {
+    animation: none;
+  }
+}

--- a/components/layout/mobile-nav/typing-prompt.tsx
+++ b/components/layout/mobile-nav/typing-prompt.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { TYPING_PHRASES } from './boot-data';
+import styles from './typing-prompt.module.css';
+
+type Phase = 'type' | 'hold' | 'erase';
+
+type TypingPromptProps = {
+  active: boolean;
+};
+
+export function TypingPrompt({ active }: TypingPromptProps) {
+  const [phraseIndex, setPhraseIndex] = useState(0);
+  const [text, setText] = useState('');
+  const [phase, setPhase] = useState<Phase>('type');
+
+  useEffect(() => {
+    if (!active) return;
+
+    const target = TYPING_PHRASES[phraseIndex];
+    let id: ReturnType<typeof setTimeout>;
+
+    if (phase === 'type') {
+      if (text.length < target.length) {
+        id = setTimeout(() => setText(target.slice(0, text.length + 1)), 65);
+      } else {
+        id = setTimeout(() => setPhase('hold'), 1000);
+      }
+    } else if (phase === 'hold') {
+      id = setTimeout(() => setPhase('erase'), 800);
+    } else {
+      if (text.length > 0) {
+        id = setTimeout(() => setText(text.slice(0, -1)), 30);
+      } else {
+        id = setTimeout(() => {
+          setPhraseIndex((i) => (i + 1) % TYPING_PHRASES.length);
+          setPhase('type');
+        }, 0);
+      }
+    }
+
+    return () => clearTimeout(id);
+  }, [active, text, phase, phraseIndex]);
+
+  return (
+    <span className={styles.prompt} aria-hidden='true'>
+      <span className={styles.dollar}>$</span>
+      <span className={styles.text}>{text}</span>
+      <span className={styles.cursor} />
+    </span>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -25,12 +25,16 @@
     "zod": "^4.4.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "husky": "^9.1.7",
+    "jsdom": "^29.1.1",
     "lint-staged": "^16.4.0",
     "prettier": "3.8.3",
     "typescript": "^5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,15 @@ importers:
         specifier: ^4.4.2
         version: 4.4.2
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -54,6 +63,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
@@ -65,9 +77,27 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.5(@types/node@20.19.39)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -124,6 +154,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -135,6 +169,46 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -182,6 +256,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -576,8 +659,40 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -868,6 +983,10 @@ packages:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
@@ -876,12 +995,19 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -953,6 +1079,9 @@ packages:
     resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -1032,11 +1161,22 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1067,6 +1207,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1078,6 +1221,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1085,6 +1232,12 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1098,6 +1251,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1426,6 +1583,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1446,6 +1607,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -1522,6 +1687,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1578,6 +1746,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1718,8 +1895,16 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.3.6:
+    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1727,6 +1912,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1739,6 +1927,10 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1853,6 +2045,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1902,6 +2097,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1926,9 +2125,16 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1937,6 +2143,10 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resend@6.12.2:
     resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
@@ -1989,6 +2199,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2120,6 +2334,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2148,6 +2366,9 @@ packages:
   svix@1.90.0:
     resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2163,9 +2384,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
+
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2217,6 +2453,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -2319,6 +2559,22 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2353,6 +2609,13 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -2375,6 +2638,28 @@ packages:
     resolution: {integrity: sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2453,6 +2738,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2475,6 +2762,34 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -2537,6 +2852,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.0': {}
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.75.0(react@19.2.4))':
     dependencies:
@@ -2798,10 +3115,46 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3046,15 +3399,23 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@5.0.1: {}
+
   ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -3145,6 +3506,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.23: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -3225,9 +3590,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3255,6 +3634,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3269,11 +3650,17 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3286,6 +3673,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -3754,6 +4143,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -3766,6 +4161,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -3850,6 +4247,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3910,6 +4309,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4032,15 +4457,21 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.3.6: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   merge2@1.4.1: {}
 
@@ -4050,6 +4481,8 @@ snapshots:
       picomatch: 2.3.2
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4177,6 +4610,10 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -4211,6 +4648,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4232,7 +4675,14 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react@19.2.4: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4253,6 +4703,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
 
   resend@6.12.2:
     dependencies:
@@ -4324,6 +4776,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -4520,6 +4976,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
@@ -4540,6 +5000,8 @@ snapshots:
       standardwebhooks: 1.0.0
       uuid: 10.0.0
 
+  symbol-tree@3.2.4: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -4551,9 +5013,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4627,6 +5103,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.25.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -4676,7 +5154,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@20.19.39)(vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@20.19.39)(jsdom@29.1.1)(vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@20.19.39)(jiti@2.6.1)(yaml@2.8.3))
@@ -4700,8 +5178,25 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4760,6 +5255,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

Replaces the bare hamburger + flat list mobile nav with a fullscreen terminal-style **boot sequence** overlay (variant A from the Claude Design handoff). The hamburger sits in the existing app header (animates to X when open) so there's no duplicate header strip; the overlay slides down beneath it via `clip-path`, with the cosmos starfield rendered inside so only the cosmos is visible behind the menu.

- **Choreography (open)**: clip-path drops down → boot log lines fade in (5 × 75 ms) → command line `\$ nav.exec --list --verbose` → menu items slide in from the left (4 × 95 ms) → typing prompt at the bottom → footer rises bottom-up with `// oferta` settling last.
- **Choreography (close)**: footer fades, menu items reverse-stagger out (last item first), boot log reverses, then clip-path collapses upward.
- **Pure CSS** for the staggered animation: each child gets `--idx`, a global `is-open` class on the overlay flips forward/reverse delays. No JS timers driving choreography (typing prompt's local state machine is the exception).
- **Accessibility**: `role=\"dialog\"`, `aria-modal`, `aria-expanded`, `aria-controls`, body scroll lock, Esc-to-close, focus moves to first link on open / returns to hamburger on close, full `prefers-reduced-motion` override.
- **Theming**: reuses `--acc` / `--ink-*` / `--line` / `--void` tokens so the overlay tracks the active theme (emerald/lime).
- **Cosmos starfield** mounts inside the overlay only while open (RAF stops on close).

Files added: `components/layout/mobile-nav/` (mobile-nav, boot-log, menu-items, footer-block, typing-prompt + boot-data). Header trimmed to just brand + desktop nav + `<MobileNav />`.

## Test plan

- [ ] Mobile viewport (≤800px): tap hamburger → boot sequence plays through; tap X → reverse animation runs to completion before overlay collapses
- [ ] Each route shows the right active item (beam + blinking caret) on `/`, `/o-mnie`, `/oferta`, `/oferta/<slug>`, `/kontakt`
- [ ] Footer service links navigate to `/oferta/<slug>` and close the overlay
- [ ] Esc closes; body scroll is locked while open; focus returns to hamburger on close
- [ ] `prefers-reduced-motion` (DevTools → Rendering): animations snap rather than ease
- [ ] Theme switch (set `[data-theme=\"lime\"]` on `<html>`): overlay accent tracks the new hue
- [ ] Desktop (≥801px): hamburger and overlay fully hidden
- [ ] No regressions on the desktop nav active-link styling