### PR TITLE
fix(mobile-nav): show overlay on iOS, type boot log like a terminal

### DIFF
--- a/components/layout/mobile-nav/boot-log.module.css
+++ b/components/layout/mobile-nav/boot-log.module.css
@@ -8,20 +8,10 @@
 .line {
   display: flex;
   gap: 10px;
-  opacity: 0;
-  transform: translateY(-4px);
-  transition:
-    opacity 180ms ease-out,
-    transform 180ms ease-out;
-  /* Resting / closing: reverse stagger (last line leaves first) */
-  transition-delay: calc((var(--total) - 1 - var(--idx)) * 25ms);
 }
 
-:global(.is-open) .line {
-  opacity: 1;
-  transform: translateY(0);
-  /* Forward stagger on open */
-  transition-delay: calc(var(--idx) * 75ms);
+.pending {
+  visibility: hidden;
 }
 
 .timestamp {
@@ -32,6 +22,9 @@
 
 .message {
   color: var(--ink-3);
+  display: inline-flex;
+  align-items: center;
+  min-height: 1em;
 }
 
 .accent .message {
@@ -46,8 +39,29 @@
   color: var(--ink-3);
 }
 
+.caret {
+  display: inline-block;
+  width: 7px;
+  height: 11px;
+  margin-left: 2px;
+  background: var(--acc);
+  box-shadow: 0 0 6px oklch(0.7 0.24 var(--theme-acc-hue, 165) / 0.5);
+  animation: bootCaret 1s steps(2) infinite;
+}
+
+@keyframes bootCaret {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  50.01%,
+  100% {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .line {
-    transition: none;
+  .caret {
+    animation: none;
   }
 }

--- a/components/layout/mobile-nav/boot-log.tsx
+++ b/components/layout/mobile-nav/boot-log.tsx
@@ -1,27 +1,91 @@
-import type { CSSProperties } from 'react';
-import { BOOT_LOG } from './boot-data';
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useReducedMotion } from '@/hooks/use-reduced-motion';
+import { BOOT_LOG, type BootLogTone } from './boot-data';
 import styles from './boot-log.module.css';
 
-export function BootLog() {
-  const total = BOOT_LOG.length;
+type BootLogProps = {
+  active: boolean;
+};
+
+const TOTAL = BOOT_LOG.length;
+const LAST_LENGTH = BOOT_LOG[TOTAL - 1].m.length;
+
+const TONE_SPEED: Record<BootLogTone, number> = {
+  accent: 14,
+  dim: 5,
+  highlight: 22,
+};
+
+const LINE_GAP_MS = 60;
+
+export function BootLog({ active }: BootLogProps) {
+  const reduced = useReducedMotion();
+  const [lineIndex, setLineIndex] = useState(0);
+  const [charCount, setCharCount] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+
+    if (reduced) {
+      if (lineIndex < TOTAL - 1 || charCount < LAST_LENGTH) {
+        const id = setTimeout(() => {
+          setLineIndex(TOTAL - 1);
+          setCharCount(LAST_LENGTH);
+        }, 0);
+        return () => clearTimeout(id);
+      }
+      return;
+    }
+
+    const line = BOOT_LOG[lineIndex];
+    if (!line) return;
+
+    if (charCount < line.m.length) {
+      const id = setTimeout(
+        () => setCharCount((c) => c + 1),
+        TONE_SPEED[line.tone]
+      );
+      return () => clearTimeout(id);
+    }
+
+    if (lineIndex < TOTAL - 1) {
+      const id = setTimeout(() => {
+        setLineIndex((i) => i + 1);
+        setCharCount(0);
+      }, LINE_GAP_MS);
+      return () => clearTimeout(id);
+    }
+  }, [active, lineIndex, charCount, reduced]);
 
   return (
     <div className={styles.log} aria-hidden='true'>
-      {BOOT_LOG.map((line, i) => (
-        <div
-          key={i}
-          className={`${styles.line} ${styles[line.tone]}`}
-          style={
-            {
-              '--idx': i,
-              '--total': total,
-            } as CSSProperties
-          }
-        >
-          <span className={styles.timestamp}>[{line.t}]</span>
-          <span className={styles.message}>{line.m}</span>
-        </div>
-      ))}
+      {BOOT_LOG.map((line, i) => {
+        const isPast = i < lineIndex;
+        const isCurrent = i === lineIndex;
+        const started = i <= lineIndex;
+        const text = isPast
+          ? line.m
+          : isCurrent
+            ? line.m.slice(0, charCount)
+            : '';
+        const showCaret = isCurrent && charCount < line.m.length;
+        return (
+          <div
+            key={i}
+            className={`${styles.line} ${styles[line.tone]} ${started ? '' : styles.pending}`}
+          >
+            <span className={styles.timestamp}>[{line.t}]</span>
+            <span className={styles.message}>
+              {text}
+              {showCaret && (
+                <span className={styles.caret} aria-hidden='true' />
+              )}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/components/layout/mobile-nav/mobile-nav.test.tsx
+++ b/components/layout/mobile-nav/mobile-nav.test.tsx
@@ -19,6 +19,16 @@ vi.mock('@/components/cosmos/background/background', () => ({
 describe('MobileNav', () => {
   beforeEach(() => {
     mockPathname = '/';
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
   });
 
   afterEach(() => {

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -23,6 +23,7 @@ const getServerSnapshot = () => false;
 export function MobileNav() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const [openSeq, setOpenSeq] = useState(0);
   const mounted = useSyncExternalStore(
     subscribeNoop,
     getClientSnapshot,
@@ -121,7 +122,7 @@ export function MobileNav() {
         </div>
       )}
 
-      <BootLog />
+      <BootLog key={openSeq} active={open} />
 
       <div className={styles.commandLine} aria-hidden='true'>
         <span className={styles.dollar}>$</span> nav.exec{' '}
@@ -153,7 +154,10 @@ export function MobileNav() {
         aria-expanded={open}
         aria-controls={overlayId}
         aria-label={open ? 'Zamknij menu' : 'Otwórz menu'}
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          if (!open) setOpenSeq((s) => s + 1);
+          setOpen((o) => !o);
+        }}
       >
         <span className={styles.bar} />
         <span className={styles.bar} />

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useEffect, useId, useRef, useState } from 'react';
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { CosmosBackground } from '@/components/cosmos/background/background';
 import { BootLog } from './boot-log';
 import { FooterBlock } from './footer-block';
@@ -9,9 +16,18 @@ import { MenuItems } from './menu-items';
 import { TypingPrompt } from './typing-prompt';
 import styles from './mobile-nav.module.css';
 
+const subscribeNoop = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export function MobileNav() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const mounted = useSyncExternalStore(
+    subscribeNoop,
+    getClientSnapshot,
+    getServerSnapshot
+  );
   const overlayId = useId();
   const buttonRef = useRef<HTMLButtonElement>(null);
   const firstLinkRef = useRef<HTMLAnchorElement>(null);
@@ -89,6 +105,44 @@ export function MobileNav() {
     buttonRef.current?.focus({ preventScroll: true });
   }, [open]);
 
+  const overlay = (
+    <div
+      ref={overlayRef}
+      id={overlayId}
+      role='dialog'
+      aria-modal='true'
+      aria-label='Menu'
+      inert={!open}
+      className={`${styles.overlay} ${open ? 'is-open' : ''}`}
+    >
+      {open && (
+        <div className={styles.cosmos} aria-hidden='true'>
+          <CosmosBackground />
+        </div>
+      )}
+
+      <BootLog />
+
+      <div className={styles.commandLine} aria-hidden='true'>
+        <span className={styles.dollar}>$</span> nav.exec{' '}
+        <span className={styles.flag}>--list</span>
+        <span className={styles.flagDim}> --verbose</span>
+      </div>
+
+      <MenuItems
+        pathname={pathname}
+        onSelect={() => setOpen(false)}
+        firstLinkRef={firstLinkRef}
+      />
+
+      <div className={styles.tail}>
+        <TypingPrompt active={open} />
+      </div>
+
+      <FooterBlock pathname={pathname} onSelect={() => setOpen(false)} />
+    </div>
+  );
+
   return (
     <div className={styles.root}>
       <button
@@ -106,41 +160,7 @@ export function MobileNav() {
         <span className={styles.bar} />
       </button>
 
-      <div
-        ref={overlayRef}
-        id={overlayId}
-        role='dialog'
-        aria-modal='true'
-        aria-label='Menu'
-        inert={!open}
-        className={`${styles.overlay} ${open ? 'is-open' : ''}`}
-      >
-        {open && (
-          <div className={styles.cosmos} aria-hidden='true'>
-            <CosmosBackground />
-          </div>
-        )}
-
-        <BootLog />
-
-        <div className={styles.commandLine} aria-hidden='true'>
-          <span className={styles.dollar}>$</span> nav.exec{' '}
-          <span className={styles.flag}>--list</span>
-          <span className={styles.flagDim}> --verbose</span>
-        </div>
-
-        <MenuItems
-          pathname={pathname}
-          onSelect={() => setOpen(false)}
-          firstLinkRef={firstLinkRef}
-        />
-
-        <div className={styles.tail}>
-          <TypingPrompt active={open} />
-        </div>
-
-        <FooterBlock pathname={pathname} onSelect={() => setOpen(false)} />
-      </div>
+      {mounted ? createPortal(overlay, document.body) : overlay}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **iOS Safari overlay bug**: the header has `backdrop-filter`, which makes it the containing block for `position: fixed` descendants. The mobile-nav overlay was rendered inside `<header>`, so its `top/right/bottom/left` were measured against the ~80px header box instead of the viewport, collapsing it to ~0px on the phone (hamburger toggled but nothing appeared). Fix: portal the overlay to `document.body` so it anchors to the viewport. Toggle stays in the header.
- **Boot log animation**: replaced the fade-in stagger with a per-character typewriter. Each line types out, a blinking caret follows the cursor, then the next line starts. Speeds vary by tone (accent 14ms/char, dim 5ms, highlight 22ms) to mimic a real boot. The animation restarts on every open via an incrementing `key`. Reduced-motion users get the final state instantly.

## Test plan

- [ ] On iPhone / Android Safari + Chrome: tap hamburger, overlay appears below the header and fills the screen
- [ ] Tap hamburger again - overlay closes, X morphs back to hamburger
- [ ] Boot log lines type out one at a time with a blinking caret on the active line
- [ ] Reopen the menu - boot animation replays from the start
- [ ] Navigate to a different route via a menu link - overlay auto-closes
- [ ] With `prefers-reduced-motion: reduce`, all boot lines render instantly with no caret animation
- [ ] Tab/Shift-Tab focus trap, Esc-to-close, and route auto-close still work