### PR TITLE
fix: mobile nav UX and oferta animation consistency

### DIFF
--- a/components/layout/mobile-nav/menu-items.module.css
+++ b/components/layout/mobile-nav/menu-items.module.css
@@ -28,7 +28,7 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 12px;
+  padding: 20px 16px;
   margin-bottom: 4px;
   border: 1px solid transparent;
   border-radius: 6px;
@@ -90,7 +90,7 @@
 
 .label {
   flex: 1;
-  font-size: 17px;
+  font-size: 22px;
   font-weight: 500;
   letter-spacing: -0.2px;
   color: var(--ink-1);

--- a/components/layout/mobile-nav/mobile-nav.tsx
+++ b/components/layout/mobile-nav/mobile-nav.tsx
@@ -11,7 +11,6 @@ import {
 import { createPortal } from 'react-dom';
 import { CosmosBackground } from '@/components/cosmos/background/background';
 import { BootLog } from './boot-log';
-import { FooterBlock } from './footer-block';
 import { MenuItems } from './menu-items';
 import { TypingPrompt } from './typing-prompt';
 import styles from './mobile-nav.module.css';
@@ -139,8 +138,6 @@ export function MobileNav() {
       <div className={styles.tail}>
         <TypingPrompt active={open} />
       </div>
-
-      <FooterBlock pathname={pathname} onSelect={() => setOpen(false)} />
     </div>
   );
 

--- a/components/sections/service-cards.module.css
+++ b/components/sections/service-cards.module.css
@@ -50,7 +50,7 @@
 }
 
 .cardVisible {
-  animation: card-reveal 0.7s cubic-bezier(0.22, 0.9, 0.3, 1) forwards;
+  animation: card-reveal 1s cubic-bezier(0.22, 0.9, 0.3, 1) forwards;
 }
 
 .card::before {


### PR DESCRIPTION
## Summary

- Enlarged mobile nav link labels from 17px to 22px and increased tap target padding from 14px/12px to 20px/16px for better readability, especially for older users
- Removed the services footer block from the mobile nav overlay to reduce clutter and keep focus on main navigation
- Slowed oferta card reveal animation from 0.7s to 1s to match the 1s scroll-reveal duration used on all other pages