### PR TITLE
fix(ui): equalize card heights and polish content

### DIFF
--- a/src/app/oferta/[slug]/page.module.css
+++ b/src/app/oferta/[slug]/page.module.css
@@ -189,31 +189,6 @@
   line-height: 1.6;
 }
 
-.deliverables {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 12px;
-}
-
-.delivItem {
-  display: flex;
-  gap: 14px;
-  align-items: baseline;
-  padding: 16px 18px;
-  border: 1px solid var(--line);
-  border-radius: 4px;
-  background: oklch(0.06 0.04 var(--theme-hue) / 0.4);
-  font-size: 13px;
-  color: var(--ink-1);
-  line-height: 1.5;
-}
-
-.delivMark {
-  color: var(--acc);
-  font-size: 10px;
-  flex-shrink: 0;
-}
-
 .breadcrumbCurrent {
   color: var(--ink-1);
 }

--- a/src/app/oferta/[slug]/page.tsx
+++ b/src/app/oferta/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { SectionLabel } from '@/components/ui/section-label';
 import { GlowFrame } from '@/components/ui/glow-frame';
 import { CosmicButton } from '@/components/ui/cosmic-button';
 import { ScrollReveal } from '@/components/ui/scroll-reveal';
+import { DeliverablesList } from '@/components/sections/deliverables-list';
 import { pageMetadata } from '@/lib/seo';
 import styles from './page.module.css';
 
@@ -148,16 +149,7 @@ export default async function ServiceDetailPage({ params }: Props) {
             kicker={servicesContent.detail.sections.efekt.kicker}
           />
         </ScrollReveal>
-        <div className={styles.deliverables}>
-          {s.deliverables.map((d, i) => (
-            <ScrollReveal key={i} delay={i * 0.07}>
-              <div className={styles.delivItem}>
-                <span className={styles.delivMark}>◇</span>
-                <span>{d}</span>
-              </div>
-            </ScrollReveal>
-          ))}
-        </div>
+        <DeliverablesList items={s.deliverables} />
       </section>
 
       <section className={styles.cta}>

--- a/src/components/sections/deliverables-list.module.css
+++ b/src/components/sections/deliverables-list.module.css
@@ -1,0 +1,50 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+@keyframes deliv-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.item {
+  display: flex;
+  gap: 14px;
+  align-items: baseline;
+  padding: 16px 18px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: oklch(0.06 0.04 var(--theme-hue) / 0.4);
+  font-size: 13px;
+  color: var(--ink-1);
+  line-height: 1.5;
+  opacity: 0;
+}
+
+.itemVisible {
+  animation: deliv-reveal 0.6s cubic-bezier(0.22, 0.9, 0.3, 1) forwards;
+}
+
+.mark {
+  color: var(--acc);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item {
+    opacity: 1;
+  }
+
+  .itemVisible {
+    animation: none;
+  }
+}

--- a/src/components/sections/deliverables-list.tsx
+++ b/src/components/sections/deliverables-list.tsx
@@ -15,12 +15,13 @@ export function DeliverablesList({ items }: Props) {
     const grid = ref.current;
     if (!grid) return;
 
+    let io: IntersectionObserver | undefined;
     if (!reduced) {
-      const io = new IntersectionObserver(
+      io = new IntersectionObserver(
         ([entry]) => {
           if (entry.isIntersecting) {
             setInView(true);
-            io.disconnect();
+            io!.disconnect();
           }
         },
         { threshold: 0.1 }
@@ -30,6 +31,7 @@ export function DeliverablesList({ items }: Props) {
 
     const equalize = () => {
       const cards = Array.from(grid.children) as HTMLElement[];
+      if (cards.length === 0) return;
       cards.forEach((c) => c.style.removeProperty('min-height'));
       const max = Math.max(...cards.map((c) => c.offsetHeight));
       cards.forEach((c) => (c.style.minHeight = `${max}px`));
@@ -38,7 +40,10 @@ export function DeliverablesList({ items }: Props) {
     equalize();
     const ro = new ResizeObserver(equalize);
     ro.observe(grid);
-    return () => ro.disconnect();
+    return () => {
+      io?.disconnect();
+      ro.disconnect();
+    };
   }, [reduced]);
 
   const visible = reduced || inView;

--- a/src/components/sections/deliverables-list.tsx
+++ b/src/components/sections/deliverables-list.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from '@/hooks/use-reduced-motion';
+import styles from './deliverables-list.module.css';
+
+type Props = { items: readonly string[] };
+
+export function DeliverablesList({ items }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reduced = useReducedMotion();
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const grid = ref.current;
+    if (!grid) return;
+
+    if (!reduced) {
+      const io = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setInView(true);
+            io.disconnect();
+          }
+        },
+        { threshold: 0.1 }
+      );
+      io.observe(grid);
+    }
+
+    const equalize = () => {
+      const cards = Array.from(grid.children) as HTMLElement[];
+      cards.forEach((c) => c.style.removeProperty('min-height'));
+      const max = Math.max(...cards.map((c) => c.offsetHeight));
+      cards.forEach((c) => (c.style.minHeight = `${max}px`));
+    };
+
+    equalize();
+    const ro = new ResizeObserver(equalize);
+    ro.observe(grid);
+    return () => ro.disconnect();
+  }, [reduced]);
+
+  const visible = reduced || inView;
+
+  return (
+    <div ref={ref} className={styles.grid}>
+      {items.map((d, i) => (
+        <div
+          key={i}
+          className={`${styles.item}${visible ? ` ${styles.itemVisible}` : ''}`}
+          style={{ animationDelay: `${i * 0.07}s` }}
+        >
+          <span aria-hidden='true' className={styles.mark}>
+            ◇
+          </span>
+          <span>{d}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/sections/service-cards.module.css
+++ b/src/components/sections/service-cards.module.css
@@ -46,7 +46,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  min-height: 320px;
+  min-height: var(--card-height, 320px);
   opacity: 0;
   transition:
     border-color 250ms,
@@ -264,7 +264,7 @@
 }
 
 .cardDetail {
-  min-height: 380px;
+  min-height: var(--card-height, 380px);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/sections/service-cards.tsx
+++ b/src/components/sections/service-cards.tsx
@@ -45,6 +45,7 @@ export function ServiceCards({
     const equalize = () => {
       grid.style.removeProperty('--card-height');
       const cards = grid.querySelectorAll<HTMLElement>(`.${styles.card}`);
+      if (cards.length === 0) return;
       const max = Math.max(...Array.from(cards).map((c) => c.offsetHeight));
       grid.style.setProperty('--card-height', `${max}px`);
     };

--- a/src/components/sections/service-cards.tsx
+++ b/src/components/sections/service-cards.tsx
@@ -39,6 +39,21 @@ export function ServiceCards({
     return () => observer.disconnect();
   }, [reduced]);
 
+  useEffect(() => {
+    const grid = gridRef.current;
+    if (!grid) return;
+    const equalize = () => {
+      grid.style.removeProperty('--card-height');
+      const cards = grid.querySelectorAll<HTMLElement>(`.${styles.card}`);
+      const max = Math.max(...Array.from(cards).map((c) => c.offsetHeight));
+      grid.style.setProperty('--card-height', `${max}px`);
+    };
+    equalize();
+    const ro = new ResizeObserver(equalize);
+    ro.observe(grid);
+    return () => ro.disconnect();
+  }, []);
+
   return (
     <div ref={gridRef} className={styles.grid}>
       {services.map((s, i) => (

--- a/src/lib/content/about.ts
+++ b/src/lib/content/about.ts
@@ -6,7 +6,7 @@ export const aboutContent = {
   },
   profile: {
     imageAlt: 'Krzysztof',
-    role: '// inżynier · krk',
+    role: '// dev & builder · krk',
     name: 'Krzysztof Obarzanek',
     bio: 'Jestem pasjonatem technologii, który kocha doradzać w doborze sprzętu, składać komputery i tworzyć strony internetowe. Moja pasja do technologii napędza mnie do nieustannego doskonalenia swoich umiejętności i tworzenia rozwiązań, które łączą innowację z praktycznością.',
     btnKontakt: 'Kontakt',

--- a/src/lib/content/home.ts
+++ b/src/lib/content/home.ts
@@ -16,7 +16,7 @@ export const homeContent = {
   oferta: {
     code: '// 02',
     title: 'Pełna oferta',
-    kicker: 'Cztery moduły, jeden inżynier',
+    kicker: 'Cztery moduły',
   },
   callout: {
     imageAlt: 'PC z RGB',

--- a/src/lib/content/services.ts
+++ b/src/lib/content/services.ts
@@ -28,7 +28,7 @@ export const servicesContent = {
       efekt: {
         code: '// efekt',
         title: 'Co dostajesz na koniec',
-        kicker: 'Konkretne deliverables',
+        kicker: 'Wynik końcowy procesu',
       },
     },
     cta: {


### PR DESCRIPTION
## Summary
  
  - Equalize service card heights using ResizeObserver + CSS custom property `--card-height`, updated on every viewport resize
  - Extract `DeliverablesList` client component with the same height equalization logic for deliverable items on service detail pages
  - Replace English kicker `'Konkretne deliverables'` with `'Wynik końcowy procesu'`